### PR TITLE
Feature: 회원가입 구직자, 고용자로 분리

### DIFF
--- a/src/main/java/land/leets/Carrot/domain/user/controller/UserController.java
+++ b/src/main/java/land/leets/Carrot/domain/user/controller/UserController.java
@@ -5,8 +5,8 @@ import static land.leets.Carrot.domain.user.controller.ResponseMessage.USER_SAVE
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import land.leets.Carrot.domain.user.dto.request.EmployeeSignupRequest;
 import land.leets.Carrot.domain.user.dto.request.LoginRequest;
-import land.leets.Carrot.domain.user.dto.request.UserSignupRequest;
 import land.leets.Carrot.domain.user.service.LoginService;
 import land.leets.Carrot.domain.user.service.UserCreateService;
 import land.leets.Carrot.global.common.response.ResponseDto;
@@ -26,9 +26,9 @@ public class UserController {
     private final UserCreateService userCreateService;
     private final LoginService loginService;
 
-    @PostMapping("/signup")
-    public ResponseEntity<ResponseDto<Void>> signup(@RequestBody @Valid UserSignupRequest request) {
-        userCreateService.signup(request);
+    @PostMapping("/employeeSignup")
+    public ResponseEntity<ResponseDto<Void>> employeeSignup(@RequestBody @Valid EmployeeSignupRequest request) {
+        userCreateService.employeeSignup(request);
         return ResponseEntity.ok(
                 ResponseDto.response(USER_SAVE_SUCCESS.getCode(), USER_SAVE_SUCCESS.getMessage())
         );

--- a/src/main/java/land/leets/Carrot/domain/user/controller/UserController.java
+++ b/src/main/java/land/leets/Carrot/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import static land.leets.Carrot.domain.user.controller.ResponseMessage.USER_SAVE
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import land.leets.Carrot.domain.user.dto.request.CeoSignupRequest;
 import land.leets.Carrot.domain.user.dto.request.EmployeeSignupRequest;
 import land.leets.Carrot.domain.user.dto.request.LoginRequest;
 import land.leets.Carrot.domain.user.service.LoginService;
@@ -29,6 +30,14 @@ public class UserController {
     @PostMapping("/employeeSignup")
     public ResponseEntity<ResponseDto<Void>> employeeSignup(@RequestBody @Valid EmployeeSignupRequest request) {
         userCreateService.employeeSignup(request);
+        return ResponseEntity.ok(
+                ResponseDto.response(USER_SAVE_SUCCESS.getCode(), USER_SAVE_SUCCESS.getMessage())
+        );
+    }
+
+    @PostMapping("/ceoSignup")
+    public ResponseEntity<ResponseDto<Void>> ceoSignup(@RequestBody @Valid CeoSignupRequest request) {
+        userCreateService.ceoSignup(request);
         return ResponseEntity.ok(
                 ResponseDto.response(USER_SAVE_SUCCESS.getCode(), USER_SAVE_SUCCESS.getMessage())
         );

--- a/src/main/java/land/leets/Carrot/domain/user/dto/request/CeoSignupRequest.java
+++ b/src/main/java/land/leets/Carrot/domain/user/dto/request/CeoSignupRequest.java
@@ -2,8 +2,12 @@ package land.leets.Carrot.domain.user.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-public class CeoSingupRequest {
+@Getter
+@NoArgsConstructor
+public class CeoSignupRequest {
     @NotNull
     private String email;
     @NotNull

--- a/src/main/java/land/leets/Carrot/domain/user/dto/request/CeoSignupRequest.java
+++ b/src/main/java/land/leets/Carrot/domain/user/dto/request/CeoSignupRequest.java
@@ -1,7 +1,6 @@
 package land.leets.Carrot.domain.user.dto.request;
 
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,5 +16,5 @@ public class CeoSignupRequest {
     @NotNull
     private String ceoName;
     @NotNull
-    private LocalDate openDate;
+    private String openDate;
 }

--- a/src/main/java/land/leets/Carrot/domain/user/dto/request/CeoSingupRequest.java
+++ b/src/main/java/land/leets/Carrot/domain/user/dto/request/CeoSingupRequest.java
@@ -1,0 +1,17 @@
+package land.leets.Carrot.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public class CeoSingupRequest {
+    @NotNull
+    private String email;
+    @NotNull
+    private String password;
+    @NotNull
+    private String ceoNumber;
+    @NotNull
+    private String ceoName;
+    @NotNull
+    private LocalDate openDate;
+}

--- a/src/main/java/land/leets/Carrot/domain/user/dto/request/EmployeeSignupRequest.java
+++ b/src/main/java/land/leets/Carrot/domain/user/dto/request/EmployeeSignupRequest.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class UserSignupRequest {
+public class EmployeeSignupRequest {
     @NotNull
     private String email;
     @NotNull

--- a/src/main/java/land/leets/Carrot/domain/user/entity/User.java
+++ b/src/main/java/land/leets/Carrot/domain/user/entity/User.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -46,11 +45,12 @@ public class User {
 
     @Column(nullable = false)
     private String ceoNumber;
-    
+
     @Column(nullable = false)
     private String ceoName;
 
-    private LocalDate openDate;
+    @Column(nullable = false)
+    private String openDate;
 
     private boolean isSmoke = false;
 

--- a/src/main/java/land/leets/Carrot/domain/user/entity/User.java
+++ b/src/main/java/land/leets/Carrot/domain/user/entity/User.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -43,8 +42,6 @@ public class User {
 
     private double temperature;
 
-    private LocalDateTime createdAt;
-
     private String selfIntroduction;
 
     private String ceoNumber;
@@ -52,8 +49,6 @@ public class User {
     private String ceoName;
 
     private LocalDate openDate;
-
-    private boolean isBusiness = false; // 사업자인지 체크
 
     private boolean isSmoke = false;
 
@@ -74,7 +69,6 @@ public class User {
         user.password = encodedPassword;
         user.phoneNumber = phoneNumber;
         user.nickname = name;
-        user.createdAt = LocalDateTime.now();
         return user;
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/user/entity/User.java
+++ b/src/main/java/land/leets/Carrot/domain/user/entity/User.java
@@ -44,8 +44,10 @@ public class User {
 
     private String selfIntroduction;
 
+    @Column(nullable = false)
     private String ceoNumber;
-
+    
+    @Column(nullable = false)
     private String ceoName;
 
     private LocalDate openDate;

--- a/src/main/java/land/leets/Carrot/domain/user/exception/ErrorMessage.java
+++ b/src/main/java/land/leets/Carrot/domain/user/exception/ErrorMessage.java
@@ -11,6 +11,9 @@ public enum ErrorMessage {
     EMAIL_ALREADY_EXISTS(400, "이미 존재하는 이메일입니다."),
     TEL_ALREADY_EXISTS(400, "이미 등록된 전화번호입니다."),
     NICKNAME_ALREADY_EXISTS(400, "이미 존재하는 닉네임입니다."),
+    CEONUMBER_ALREADY_EXISTS(400, "이미 존재하는 사업자 번호입니다"),
+    CEONAME_ALREADY_EXISTS(400, "이미 존재하는 사업자 이름입니다."),
+
     // 로그인 관련
     USER_NOT_FOUND(404, "존재하지 않는 유저입니다."),
     INVALID_PASSWORD(401, "비밀번호가 일치하지 않습니다.");

--- a/src/main/java/land/leets/Carrot/domain/user/exception/ErrorMessage.java
+++ b/src/main/java/land/leets/Carrot/domain/user/exception/ErrorMessage.java
@@ -7,11 +7,12 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorMessage {
-
-    USER_NOT_FOUND(404, "존재하지 않는 유저입니다."),
+    // 회원가입 관련
     EMAIL_ALREADY_EXISTS(400, "이미 존재하는 이메일입니다."),
     TEL_ALREADY_EXISTS(400, "이미 등록된 전화번호입니다."),
     NICKNAME_ALREADY_EXISTS(400, "이미 존재하는 닉네임입니다."),
+    // 로그인 관련
+    USER_NOT_FOUND(404, "존재하지 않는 유저입니다."),
     INVALID_PASSWORD(401, "비밀번호가 일치하지 않습니다.");
 
     private final int code;

--- a/src/main/java/land/leets/Carrot/domain/user/repository/UserRepository.java
+++ b/src/main/java/land/leets/Carrot/domain/user/repository/UserRepository.java
@@ -11,5 +11,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByNickname(String nickname);
 
+    boolean existsByCeoNumber(String ceoNumber);
+
+    boolean existsByCeoName(String ceoName);
+
     Optional<User> findByEmail(String email);
 }

--- a/src/main/java/land/leets/Carrot/domain/user/service/UserCreateService.java
+++ b/src/main/java/land/leets/Carrot/domain/user/service/UserCreateService.java
@@ -60,7 +60,7 @@ public class UserCreateService {
         String encodedPassword = passwordEncoder.encode(request.getPassword());
         User user = User.createWithEncodedPassword(
                 request.getEmail(), encodedPassword,
-                null, request.getCeoName()
+                request.getCeoNumber(), request.getCeoName()
         );
 
         userRepository.save(user);

--- a/src/main/java/land/leets/Carrot/domain/user/service/UserCreateService.java
+++ b/src/main/java/land/leets/Carrot/domain/user/service/UserCreateService.java
@@ -2,7 +2,7 @@ package land.leets.Carrot.domain.user.service;
 
 import java.util.Optional;
 import java.util.stream.Stream;
-import land.leets.Carrot.domain.user.dto.request.UserSignupRequest;
+import land.leets.Carrot.domain.user.dto.request.EmployeeSignupRequest;
 import land.leets.Carrot.domain.user.dto.response.UserInfoResponse;
 import land.leets.Carrot.domain.user.entity.User;
 import land.leets.Carrot.domain.user.exception.ErrorMessage;
@@ -20,7 +20,7 @@ public class UserCreateService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public UserInfoResponse signup(UserSignupRequest request) {
+    public UserInfoResponse employeeSignup(EmployeeSignupRequest request) {
         // 이메일과 전화번호 중복 검사
         Stream.of(
                         checkEmailExists(request.getEmail()),


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
기존 회원가입 및 로그인 로직에 사업자 전용 회원가입 로직을 추가하기 위해 코드가 수정되었습니다.
클라이언트가 구직자 고용자 각각 다른 경로로 회원가입할 수 있도록 API를 구분하여 **/employeeSignup**과 **/ceoSignup**을 추가했습니다
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
