### PR TITLE
Refactor: global 예외처리 수정

### DIFF
--- a/src/main/java/land/leets/Carrot/domain/user/exception/InvalidPasswordException.java
+++ b/src/main/java/land/leets/Carrot/domain/user/exception/InvalidPasswordException.java
@@ -5,6 +5,6 @@ import land.leets.Carrot.global.common.exception.BaseException;
 public class InvalidPasswordException extends BaseException {
 
     public InvalidPasswordException(ErrorMessage errorMessage) {
-        super(errorMessage.getMessage());
+        super(errorMessage.getCode(), errorMessage.getMessage());
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/user/exception/UserAlreadyExistsException.java
+++ b/src/main/java/land/leets/Carrot/domain/user/exception/UserAlreadyExistsException.java
@@ -4,6 +4,6 @@ import land.leets.Carrot.global.common.exception.BaseException;
 
 public class UserAlreadyExistsException extends BaseException {
     public UserAlreadyExistsException(ErrorMessage errorMessage) {
-        super(errorMessage.getMessage());
+        super(errorMessage.getCode(), errorMessage.getMessage());
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/land/leets/Carrot/domain/user/exception/UserNotFoundException.java
@@ -4,6 +4,6 @@ import land.leets.Carrot.global.common.exception.BaseException;
 
 public class UserNotFoundException extends BaseException {
     public UserNotFoundException(ErrorMessage errorMessage) {
-        super(errorMessage.getMessage());
+        super(errorMessage.getCode(), errorMessage.getMessage());
     }
 }

--- a/src/main/java/land/leets/Carrot/global/common/exception/BaseException.java
+++ b/src/main/java/land/leets/Carrot/global/common/exception/BaseException.java
@@ -1,8 +1,12 @@
 package land.leets.Carrot.global.common.exception;
 
 public class BaseException extends RuntimeException {
-    public BaseException(String message) {
+
+    private final int errorCode;
+
+    public BaseException(int errorCode, String message) {
         super(message);
+        this.errorCode = errorCode;
         // 나중에 InvalidInputException 등 예외처리
     }
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
BaseException에서 예외처리가 예외상황시, 메세지만 반환되는 로직이라
에러코드까지 반환해줘야해서 코드를 수정했습니다
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항
BaseException 예외처리시 예외코드도 같이 반환하도록 수정했습니다
BaseException 상속하는 예외도 코드까지 반환하도록 수정했습니다
메인에 머지시, api에서 개발하는 예외처리는 모두 global에 있는 BaseException을 상속하도록 설계해주시기 바랍니다.
<br>

## 5. 추가 사항
