### PR TITLE
Refactor: PostException 로직 분리

### DIFF
--- a/src/main/java/land/leets/Carrot/domain/post/exception/PostErrorMessage.java
+++ b/src/main/java/land/leets/Carrot/domain/post/exception/PostErrorMessage.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum ErrorMessage {
+public enum PostErrorMessage {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 글을 찾을 수 없습니다."),
     LATEST_SNAPSHOT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 게시글의 최신 버전 스냅샷을 찾을 수 없습니다"),
     SEARCH_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 키워드를 포함하는 게시글이 없습니다.."),

--- a/src/main/java/land/leets/Carrot/domain/post/exception/PostException.java
+++ b/src/main/java/land/leets/Carrot/domain/post/exception/PostException.java
@@ -1,0 +1,9 @@
+package land.leets.Carrot.domain.post.exception;
+
+import land.leets.Carrot.global.common.exception.BaseException;
+
+public class PostException extends BaseException {
+    public PostException(PostErrorMessage error) {
+        super(error.getCode(), error.getErrorMessage());
+    }
+}

--- a/src/main/java/land/leets/Carrot/global/common/exception/BaseException.java
+++ b/src/main/java/land/leets/Carrot/global/common/exception/BaseException.java
@@ -1,7 +1,5 @@
 package land.leets.Carrot.global.common.exception;
 
-import land.leets.Carrot.domain.post.exception.ErrorMessage;
-
 public class BaseException extends RuntimeException {
 
     private final int errorCode;
@@ -10,10 +8,5 @@ public class BaseException extends RuntimeException {
         super(message);
         this.errorCode = errorCode;
         // 나중에 InvalidInputException 등 예외처리
-    }
-
-    public BaseException(ErrorMessage errorMessage) {
-        super(errorMessage.getErrorMessage());
-        this.errorCode = errorMessage.getCode();
     }
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
close #26 
기존 Post CRUD 작업하면서 BaseException을 직접 생성해 throw 하는 방법으로 구현하였는데, 유지보수 및 책임 분리를 목적으로 BaseException을 상속한 Post 도메인 범위에서만 사용하는 범위의 PostException을 구현해 교체하였습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
코드 검토를 진행하던 중 기존의 BaseException 을 직접 사용하는 부분에서 BaseException의 책임 과중 및 로직 일관성 탈락을 발견해 수정 진행함
<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항
PostException을 생성하여 Post 도메인 내에서 throw되는 exception은 PostException을 사용해 exception발생하도록 수정하였습니다.
<br>

## 5. 추가 사항
