### PR TITLE
Refactor : post 조회, 마감 상태 변환 API

### DIFF
--- a/src/main/java/land/leets/Carrot/domain/post/controller/PostController.java
+++ b/src/main/java/land/leets/Carrot/domain/post/controller/PostController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -72,5 +73,11 @@ public class PostController {
     @GetMapping("/work/type")
     public ResponseEntity<ResponseDto<WorkTypeResponse>> getCurrentExistWorkType() {
         return ResponseEntity.ok(workTypeService.getWorkType());
+    }
+
+    @PatchMapping("/status/{postId}")
+    public ResponseEntity<Void> getPostStatusDone(@PathVariable Long postId) {
+        postService.updatePostStatusDone(postId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/post/dto/response/PostResponse.java
+++ b/src/main/java/land/leets/Carrot/domain/post/dto/response/PostResponse.java
@@ -9,6 +9,7 @@ public record PostResponse(
         Long userId,
         @NotNull
         String storeName,
+        String writerNickname,
         PostData postData
 
 ) {

--- a/src/main/java/land/leets/Carrot/domain/post/entity/Post.java
+++ b/src/main/java/land/leets/Carrot/domain/post/entity/Post.java
@@ -6,10 +6,13 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.Set;
 import land.leets.Carrot.domain.apply.entity.Apply;
+import land.leets.Carrot.domain.user.entity.Ceo;
 import land.leets.Carrot.global.common.domain.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -26,8 +29,9 @@ public class Post extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long postId;
 
-    @Column(name = "user_id", nullable = false)
-    private long userId;
+    @ManyToOne
+    @JoinColumn(name = "ceo_id", nullable = false)
+    private Ceo ceo;
 
     @Column(name = "store_name", nullable = false)
     private String storeName;
@@ -44,8 +48,8 @@ public class Post extends BaseTimeEntity {
     private Set<Apply> apply;
 
     @Builder
-    public Post(long userId, String storeName, LocalDateTime createAt, String status) {
-        this.userId = userId;
+    public Post(Ceo ceo, String storeName, LocalDateTime createAt, String status) {
+        this.ceo = ceo;
         this.storeName = storeName;
         this.createAt = createAt;
         this.status = status;

--- a/src/main/java/land/leets/Carrot/domain/post/entity/PostSnapshot.java
+++ b/src/main/java/land/leets/Carrot/domain/post/entity/PostSnapshot.java
@@ -114,4 +114,8 @@ public class PostSnapshot extends BaseTimeEntity {
         this.payType = payType;
     }
 
+    public void setIsLastest(boolean isLastest){
+        this.isLastest = isLastest;
+    }
+
 }

--- a/src/main/java/land/leets/Carrot/domain/post/exception/PostErrorMessage.java
+++ b/src/main/java/land/leets/Carrot/domain/post/exception/PostErrorMessage.java
@@ -14,7 +14,8 @@ public enum PostErrorMessage {
     WROTE_POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "작성한 게시글이 없습니다."),
 
     WORK_TYPE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR.value(), "존재하는 업무 아이디의 업무내용을 찾을 수 없습니다."),
-    LOCATION_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR.value(), "존재하는 지역 아이디의 지역명을 찾을 수 없습니다."),;
+    LOCATION_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR.value(), "존재하는 지역 아이디의 지역명을 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR.value(), "작성자 유저를 찾을 수 없습니다.");
     private final Integer code;
     private final String errorMessage;
 }

--- a/src/main/java/land/leets/Carrot/domain/post/repository/PostRepository.java
+++ b/src/main/java/land/leets/Carrot/domain/post/repository/PostRepository.java
@@ -14,6 +14,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT post FROM Post post WHERE post.status=:status")
     Optional<List<Post>> findByStatus(@Param("status") String status);
 
-    @Query("SELECT post FROM Post post WHERE post.userId=:userId")
+    @Query("SELECT post FROM Post post WHERE post.ceo.id=:userId")
     Optional<List<Post>> findByWriterId(@Param("userId") Long userId);
 }

--- a/src/main/java/land/leets/Carrot/domain/post/service/PostService.java
+++ b/src/main/java/land/leets/Carrot/domain/post/service/PostService.java
@@ -146,6 +146,14 @@ public class PostService {
         postRepository.save(post);
     }
 
+    @Transactional
+    public void updatePostStatusDone(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(POST_NOT_FOUND));
+        post.setStatus(POST_STATUS_DONE);
+        postRepository.save(post);
+    }
+
     //홈 화면에서 간략한 게시글 데이터 리스트 조회
     public ResponseDto<ShortPostResponse> getShortPostData() {
         List<Post> postList = postRepository.findByStatus(POST_STATUS_RECRUITING)

--- a/src/main/java/land/leets/Carrot/domain/post/service/PostService.java
+++ b/src/main/java/land/leets/Carrot/domain/post/service/PostService.java
@@ -85,7 +85,7 @@ public class PostService {
         //기존 snapshot isLastest false로 수정
         PostSnapshot postSnapshot = postSnapshotRepository.findByPostIdAndIsLastestTrue(postId)
                 .orElseThrow(() -> new PostException(LATEST_SNAPSHOT_NOT_FOUND));
-        postSnapshot.setLastest(false);
+        postSnapshot.setIsLastest(false);
         postSnapshotRepository.save(postSnapshot);
 
         //PostSnapshot 생성해서 새 PostSnapshot 저장

--- a/src/main/java/land/leets/Carrot/domain/user/entity/Ceo.java
+++ b/src/main/java/land/leets/Carrot/domain/user/entity/Ceo.java
@@ -2,6 +2,10 @@ package land.leets.Carrot.domain.user.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+import java.util.Set;
+import land.leets.Carrot.domain.post.entity.Post;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,6 +28,10 @@ public class Ceo extends User {
 
     @Column(nullable = false)
     private String openDate;
+
+    @OneToMany(mappedBy = "ceo", fetch = FetchType.LAZY)
+    private Set<Post> post;
+
 
     public Ceo(String email, String password, String ceoName, String ceoPhoneNumber, String ceoNumber, String storeName,
                String openDate) {


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
close #29 
게시글 상태 수정 API 를 삭제상태, 마감상태로 수정하는 것을 API를 분리해서 구현하고자 함.
post 상세 조회시 게시글 작성자의 유저명, id가 필요해 response및 엔티티 매핑 관계 수정

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
![image](https://github.com/user-attachments/assets/21696e79-27aa-4c40-b8b5-0c73aa8b1b4e)
더미데이터는...대강 만들었습니다 정상작동 합니다
<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
