### PR TITLE
Feature : 프로필 이미지 생성수정 및 삭제 기능 구현

### DIFF
--- a/src/main/java/land/leets/Carrot/domain/image/service/S3ImageService.java
+++ b/src/main/java/land/leets/Carrot/domain/image/service/S3ImageService.java
@@ -1,0 +1,87 @@
+package land.leets.Carrot.domain.image.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import land.leets.Carrot.domain.user.exception.FileConversionFailedException;
+import land.leets.Carrot.domain.user.exception.InvalidFileExtensionException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3ImageService {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    // 단일 이미지 업로드 메서드
+    public String uploadImage(MultipartFile image, String dirName) {
+        validateImageFileExtension(image.getOriginalFilename());
+
+        String fileName = createUniqueFileName(image.getOriginalFilename(), dirName);
+        log.info("fileName: {}", fileName);
+
+        File uploadFile = convertToFile(image);
+
+        try {
+            return uploadToS3(uploadFile, fileName);
+        } finally {
+            deleteLocalFile(uploadFile);
+        }
+    }
+
+    // 파일 확장자 유효성 검증
+    private void validateImageFileExtension(String filename) {
+        String extension = filename.substring(filename.lastIndexOf(".") + 1).toLowerCase();
+        if (!List.of("jpg", "jpeg", "png", "gif").contains(extension)) {
+            throw new InvalidFileExtensionException();
+        }
+    }
+
+    // 고유한 파일명 생성 메서드
+    private String createUniqueFileName(String originalFileName, String dirName) {
+        String uuid = UUID.randomUUID().toString();
+        String uniqueFileName = uuid + "_" + originalFileName.replaceAll("\\s", "_");
+        return dirName + "/" + uniqueFileName;
+    }
+
+    // MultipartFile을 File로 변환
+    private File convertToFile(MultipartFile multipartFile) {
+        File file = new File(multipartFile.getOriginalFilename());
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(multipartFile.getBytes());
+        } catch (IOException e) {
+            log.error("파일 변환 중 오류 발생: {}", e.getMessage());
+            throw new FileConversionFailedException();
+        }
+        return file;
+    }
+
+    // S3에 업로드 및 URL 반환
+    private String uploadToS3(File uploadFile, String fileName) {
+        amazonS3.putObject(new PutObjectRequest(bucketName, fileName, uploadFile)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3.getUrl(bucketName, fileName).toString();
+    }
+
+    // 로컬 파일 삭제
+    private void deleteLocalFile(File file) {
+        if (file.delete()) {
+            log.info("Local file deleted: {}", file.getName());
+        } else {
+            log.warn("Failed to delete local file: {}", file.getName());
+        }
+    }
+}

--- a/src/main/java/land/leets/Carrot/domain/image/service/S3ImageService.java
+++ b/src/main/java/land/leets/Carrot/domain/image/service/S3ImageService.java
@@ -2,6 +2,7 @@ package land.leets.Carrot.domain.image.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -9,6 +10,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import land.leets.Carrot.domain.user.exception.FileConversionFailedException;
+import land.leets.Carrot.domain.user.exception.ImageDeleteException;
 import land.leets.Carrot.domain.user.exception.InvalidFileExtensionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +41,21 @@ public class S3ImageService {
             return uploadToS3(uploadFile, fileName);
         } finally {
             deleteLocalFile(uploadFile);
+        }
+    }
+
+    public String updateImage(MultipartFile newImage, String oldFileName, String dirName) {
+        deleteImage(oldFileName);
+        return uploadImage(newImage, dirName);
+    }
+
+    public void deleteImage(String fileName) {
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, fileName));
+            log.info("Image deleted from S3: {}", fileName);
+        } catch (Exception e) {
+            log.error("Error while deleting image from S3: {}", e.getMessage());
+            throw new ImageDeleteException();
         }
     }
 
@@ -84,4 +101,5 @@ public class S3ImageService {
             log.warn("Failed to delete local file: {}", file.getName());
         }
     }
+
 }

--- a/src/main/java/land/leets/Carrot/domain/user/controller/ResponseMessage.java
+++ b/src/main/java/land/leets/Carrot/domain/user/controller/ResponseMessage.java
@@ -10,13 +10,19 @@ public enum ResponseMessage {
     //로그인 회원가입 관련
     USER_SAVE_SUCCESS(201, "회원가입 성공."),
     LOGIN_SUCCESS(200, "로그인 성공."),
+
     //마이페이지(프로필) 관련
     PROFILE_CHECK_SUCCESS(200, "프로필 조회 성공."),
     BASIC_INFO_UPDATE_SUCCESS(200, "프로필 기본정보 수정 성공"),
     CAREER_UPDATE_SUCCESS(200, "경력 정보 수정 성공"),
     SELF_INTRO_UPDATE_SUCCESS(200, "자기소개 정보 수정 성공"),
     ADDITIONAL_INFO_UPDATE_SUCCESS(200, "추가 정보 수정 성공"),
-    STRENGTH_UPDATE_SUCCESS(200, "장점 정보 수정 성공");
+    STRENGTH_UPDATE_SUCCESS(200, "장점 정보 수정 성공"),
+
+    // 이미지 업로드 관련
+    IMAGE_UPLOAD_SUCCESS(200, "이미지 업로드 성공."),
+    IMAGE_DELETE_SUCCESS(200, "이미지 삭제 성공.");
+    
     private final int code;
     private final String message;
 

--- a/src/main/java/land/leets/Carrot/domain/user/controller/ResponseMessage.java
+++ b/src/main/java/land/leets/Carrot/domain/user/controller/ResponseMessage.java
@@ -21,8 +21,9 @@ public enum ResponseMessage {
 
     // 이미지 업로드 관련
     IMAGE_UPLOAD_SUCCESS(200, "이미지 업로드 성공."),
+    IMAGE_UPDATE_SUCCESS(200, "이미지 수정 성공."),
     IMAGE_DELETE_SUCCESS(200, "이미지 삭제 성공.");
-    
+
     private final int code;
     private final String message;
 

--- a/src/main/java/land/leets/Carrot/domain/user/controller/UserProfileController.java
+++ b/src/main/java/land/leets/Carrot/domain/user/controller/UserProfileController.java
@@ -3,6 +3,7 @@ package land.leets.Carrot.domain.user.controller;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.ADDITIONAL_INFO_UPDATE_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.BASIC_INFO_UPDATE_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.CAREER_UPDATE_SUCCESS;
+import static land.leets.Carrot.domain.user.controller.ResponseMessage.IMAGE_UPLOAD_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.PROFILE_CHECK_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.SELF_INTRO_UPDATE_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.STRENGTH_UPDATE_SUCCESS;
@@ -10,6 +11,7 @@ import static land.leets.Carrot.domain.user.controller.ResponseMessage.STRENGTH_
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
+import land.leets.Carrot.domain.image.service.S3ImageService;
 import land.leets.Carrot.domain.user.dto.request.BasicInfoUpdateRequest;
 import land.leets.Carrot.domain.user.dto.request.EmployeeAdditionalInfoUpdateRequest;
 import land.leets.Carrot.domain.user.dto.request.EmployeeCareerUpdateRequest;
@@ -22,15 +24,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/user-profiles")
 public class UserProfileController {
     private final UserProfileService userProfileService;
+    private final S3ImageService s3ImageService;
 
     @GetMapping("/profile")
     @Operation(summary = "프로필 메인 페이지")
@@ -97,6 +103,19 @@ public class UserProfileController {
         return ResponseEntity.ok(
                 ResponseDto.response(STRENGTH_UPDATE_SUCCESS.getCode(),
                         STRENGTH_UPDATE_SUCCESS.getMessage())
+        );
+    }
+
+    @PostMapping("/upload-profile-image")
+    @Operation(summary = "프로필 이미지 업로드")
+    public ResponseEntity<ResponseDto<String>> uploadProfileImage(
+            @RequestParam("image") MultipartFile image,
+            @Parameter(hidden = true) @CurrentUser Long userId) {
+        String imageUrl = s3ImageService.uploadImage(image, "profile-images");
+        userProfileService.updateProfileImageUrl(userId, imageUrl);
+        return ResponseEntity.ok(
+                ResponseDto.response(IMAGE_UPLOAD_SUCCESS.getCode(),
+                        IMAGE_UPLOAD_SUCCESS.getMessage(), imageUrl)
         );
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/user/controller/UserProfileController.java
+++ b/src/main/java/land/leets/Carrot/domain/user/controller/UserProfileController.java
@@ -3,6 +3,8 @@ package land.leets.Carrot.domain.user.controller;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.ADDITIONAL_INFO_UPDATE_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.BASIC_INFO_UPDATE_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.CAREER_UPDATE_SUCCESS;
+import static land.leets.Carrot.domain.user.controller.ResponseMessage.IMAGE_DELETE_SUCCESS;
+import static land.leets.Carrot.domain.user.controller.ResponseMessage.IMAGE_UPDATE_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.IMAGE_UPLOAD_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.PROFILE_CHECK_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.SELF_INTRO_UPDATE_SUCCESS;
@@ -22,6 +24,7 @@ import land.leets.Carrot.global.auth.annotation.CurrentUser;
 import land.leets.Carrot.global.common.response.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -116,6 +119,33 @@ public class UserProfileController {
         return ResponseEntity.ok(
                 ResponseDto.response(IMAGE_UPLOAD_SUCCESS.getCode(),
                         IMAGE_UPLOAD_SUCCESS.getMessage(), imageUrl)
+        );
+    }
+
+    @PatchMapping("/update-profile-image")
+    @Operation(summary = "프로필 이미지 수정")
+    public ResponseEntity<ResponseDto<String>> updateProfileImage(
+            @RequestParam("image") MultipartFile image,
+            @RequestParam("oldFileName") String oldFileName,
+            @Parameter(hidden = true) @CurrentUser Long userId) {
+        String imageUrl = s3ImageService.updateImage(image, oldFileName, "profile-images");
+        userProfileService.updateProfileImageUrl(userId, imageUrl);
+        return ResponseEntity.ok(
+                ResponseDto.response(IMAGE_UPDATE_SUCCESS.getCode(),
+                        IMAGE_UPDATE_SUCCESS.getMessage(), imageUrl)
+        );
+    }
+
+    @DeleteMapping("/delete-profile-image")
+    @Operation(summary = "프로필 이미지 삭제")
+    public ResponseEntity<ResponseDto<Void>> deleteProfileImage(
+            @RequestParam("fileName") String fileName,
+            @Parameter(hidden = true) @CurrentUser Long userId) {
+        s3ImageService.deleteImage(fileName);
+        userProfileService.updateProfileImageUrl(userId, null);
+        return ResponseEntity.ok(
+                ResponseDto.response(IMAGE_DELETE_SUCCESS.getCode(),
+                        IMAGE_DELETE_SUCCESS.getMessage())
         );
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/user/entity/User.java
+++ b/src/main/java/land/leets/Carrot/domain/user/entity/User.java
@@ -32,6 +32,8 @@ public class User {
 
     private Integer birthYear;
 
+    private String profileImageUrl;
+
     public User(String email, String password) {
         this.email = email;
         this.password = password;
@@ -40,5 +42,9 @@ public class User {
     public void updateBasicInfo(Gender gender, Integer birthYear) {
         this.gender = gender;
         this.birthYear = birthYear;
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/user/exception/ErrorMessage.java
+++ b/src/main/java/land/leets/Carrot/domain/user/exception/ErrorMessage.java
@@ -23,7 +23,8 @@ public enum ErrorMessage {
 
     // 이미지 업로드 관련
     INVALID_FILE_EXTENSION(400, "유효하지 않은 파일 형식입니다."),
-    FILE_CONVERSION_FAILED(500, "파일 변환에 실패했습니다.");
+    FILE_CONVERSION_FAILED(500, "파일 변환에 실패했습니다."),
+    IMAGE_DELETE_FAILED(500, "이미지 삭제에 실패했습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/land/leets/Carrot/domain/user/exception/ErrorMessage.java
+++ b/src/main/java/land/leets/Carrot/domain/user/exception/ErrorMessage.java
@@ -19,7 +19,11 @@ public enum ErrorMessage {
 
     // 유저 프로필 관련
     UNKNOWN_USER_TYPE(400, "정의되지 않은 유저 타입입니다."),
-    INVALID_USER_TYPE(400, "구직자만 수정 가능한 정보입니다.");
+    INVALID_USER_TYPE(400, "구직자만 수정 가능한 정보입니다."),
+
+    // 이미지 업로드 관련
+    INVALID_FILE_EXTENSION(400, "유효하지 않은 파일 형식입니다."),
+    FILE_CONVERSION_FAILED(500, "파일 변환에 실패했습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/land/leets/Carrot/domain/user/exception/FileConversionFailedException.java
+++ b/src/main/java/land/leets/Carrot/domain/user/exception/FileConversionFailedException.java
@@ -1,0 +1,9 @@
+package land.leets.Carrot.domain.user.exception;
+
+import land.leets.Carrot.global.common.exception.BaseException;
+
+public class FileConversionFailedException extends BaseException {
+    public FileConversionFailedException() {
+        super(ErrorMessage.FILE_CONVERSION_FAILED.getCode(), ErrorMessage.FILE_CONVERSION_FAILED.getMessage());
+    }
+}

--- a/src/main/java/land/leets/Carrot/domain/user/exception/ImageDeleteException.java
+++ b/src/main/java/land/leets/Carrot/domain/user/exception/ImageDeleteException.java
@@ -1,0 +1,11 @@
+package land.leets.Carrot.domain.user.exception;
+
+import static land.leets.Carrot.domain.user.exception.ErrorMessage.IMAGE_DELETE_FAILED;
+
+import land.leets.Carrot.global.common.exception.BaseException;
+
+public class ImageDeleteException extends BaseException {
+    public ImageDeleteException() {
+        super(IMAGE_DELETE_FAILED.getCode(), IMAGE_DELETE_FAILED.getMessage());
+    }
+}

--- a/src/main/java/land/leets/Carrot/domain/user/exception/InvalidFileExtensionException.java
+++ b/src/main/java/land/leets/Carrot/domain/user/exception/InvalidFileExtensionException.java
@@ -1,0 +1,9 @@
+package land.leets.Carrot.domain.user.exception;
+
+import land.leets.Carrot.global.common.exception.BaseException;
+
+public class InvalidFileExtensionException extends BaseException {
+    public InvalidFileExtensionException() {
+        super(ErrorMessage.INVALID_FILE_EXTENSION.getCode(), ErrorMessage.INVALID_FILE_EXTENSION.getMessage());
+    }
+}

--- a/src/main/java/land/leets/Carrot/domain/user/service/UserProfileService.java
+++ b/src/main/java/land/leets/Carrot/domain/user/service/UserProfileService.java
@@ -121,4 +121,11 @@ public class UserProfileService {
             throw new InvalidUserTypeException();
         }
     }
+
+    @Transactional
+    public void updateProfileImageUrl(Long userId, String imageUrl) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+        user.updateProfileImageUrl(imageUrl);  // 새로운 메서드를 통한 업데이트
+    }
 }

--- a/src/main/java/land/leets/Carrot/global/config/AwsS3Config.java
+++ b/src/main/java/land/leets/Carrot/global/config/AwsS3Config.java
@@ -1,0 +1,32 @@
+package land.leets.Carrot.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String accessSecret;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 s3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, accessSecret);
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -20,3 +20,14 @@ carrot:
     refresh:
       expiration: ${REFRESH_EXP}
       header: ${REFRESH_HEAD}
+cloud:
+  aws:
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+    s3:
+      bucket: ${S3_BUCKET}
+    region:
+      static: ${S3_REGION}
+    stack:
+      auto: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,3 +20,12 @@ carrot:
     refresh:
       expiration: ${REFRESH_EXP}
       header: ${REFRESH_HEAD}
+cloud:
+  aws:
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+    s3:
+      bucket: ${S3_BUCKET}
+    region:
+      static: ${S3_REGION}


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
사용자 프로필에 이미지 업로드, 수정, 삭제 기능을 구현하기 위해 S3를 활용한 이미지 저장소를 설정했습니다.
이미지 업로드, 수정, 삭제 시 예외처리 커스텀 메시지 + 성공 응답 메시지를 추가했습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="715" alt="image" src="https://github.com/user-attachments/assets/3c7925cc-df31-4a1f-9274-9f75078d128f">

<br>

## 4. 완료 사항
uploadImage: S3에 파일을 업로드하고 URL 반환.
updateProfileImage: 프로필 이미지 URL 수정 기능
deleteImage: S3 버킷 내 기존 이미지를 삭제하는 기능
<br>

## 5. 추가 사항
S3 환경 변수 설정과 AwsS3Config 클래스 생성(환경변수는 노션에 정리해놨습니다)
application.yml에 S3 관련 환경 변수 설정 추가.
S3 버킷 정책과 CORS 설정을 통해 외부에서의 접근과 도메인 접근 제한 설정 완료.
