### PR TITLE
Refactor: PostSnapshot Post 매핑방식 변경

### DIFF
--- a/src/main/java/land/leets/Carrot/domain/post/controller/PostController.java
+++ b/src/main/java/land/leets/Carrot/domain/post/controller/PostController.java
@@ -45,7 +45,7 @@ public class PostController {
 
     @GetMapping("/{postId}")
     public ResponseEntity<ResponseDto<PostResponse>> getPost(@PathVariable Long postId) {
-        return ResponseEntity.ok(postService.getPost(postId));
+        return ResponseEntity.ok(postService.getDetailPost(postId));
     }
 
     @DeleteMapping("/{postId}")

--- a/src/main/java/land/leets/Carrot/domain/post/entity/Post.java
+++ b/src/main/java/land/leets/Carrot/domain/post/entity/Post.java
@@ -27,7 +27,11 @@ import lombok.Setter;
 public class Post extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id", nullable = false)
     private long postId;
+
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    private Set<PostSnapshot> postSnapshot;
 
     @ManyToOne
     @JoinColumn(name = "ceo_id", nullable = false)

--- a/src/main/java/land/leets/Carrot/domain/post/entity/PostSnapshot.java
+++ b/src/main/java/land/leets/Carrot/domain/post/entity/PostSnapshot.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import java.util.EnumSet;
 import java.util.Set;
@@ -27,13 +29,15 @@ public class PostSnapshot extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
+    @ManyToOne
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
     private int doAreaId;
 
     private int siAreaId;
 
     private int detailAreaId;
-
-    private long postId;
 
     private Integer workTypeId;
 
@@ -82,7 +86,7 @@ public class PostSnapshot extends BaseTimeEntity {
     public PostSnapshot(int doAreaId,
                         int siAreaId,
                         int detailAreaId,
-                        long postId,
+                        Post post,
                         Integer workTypeId,
                         String title,
                         String content,
@@ -97,7 +101,7 @@ public class PostSnapshot extends BaseTimeEntity {
         this.doAreaId = doAreaId;
         this.siAreaId = siAreaId;
         this.detailAreaId = detailAreaId;
-        this.postId = postId;
+        this.post = post;
         this.workTypeId = workTypeId;
         this.title = title;
         this.content = content;
@@ -114,7 +118,7 @@ public class PostSnapshot extends BaseTimeEntity {
         this.payType = payType;
     }
 
-    public void setIsLastest(boolean isLastest){
+    public void setIsLastest(boolean isLastest) {
         this.isLastest = isLastest;
     }
 

--- a/src/main/java/land/leets/Carrot/domain/post/mapper/PostDataMapper.java
+++ b/src/main/java/land/leets/Carrot/domain/post/mapper/PostDataMapper.java
@@ -1,6 +1,7 @@
 package land.leets.Carrot.domain.post.mapper;
 
 import land.leets.Carrot.domain.post.domain.PostData;
+import land.leets.Carrot.domain.post.entity.Post;
 import land.leets.Carrot.domain.post.entity.PostSnapshot;
 import org.springframework.stereotype.Component;
 
@@ -8,12 +9,12 @@ import org.springframework.stereotype.Component;
 public class PostDataMapper {
     //단기 알바인 경우는 미반영, 일단 장기 알바만을 고려 isShortTerm 은 아직 고려안함
     public static PostSnapshot postDataToPostSnapshot(PostData postData, Integer doAreaId, Integer siAreaId,
-                                                      Integer detailAreaId, Integer jobTypeId, Long postId) {
+                                                      Integer detailAreaId, Integer jobTypeId, Post post) {
         return PostSnapshot.builder()
                 .doAreaId(doAreaId)
                 .siAreaId(siAreaId)
                 .detailAreaId(detailAreaId)
-                .postId(postId)
+                .post(post)
                 .workTypeId(jobTypeId)
                 .title(postData.title())
                 .content(postData.content())

--- a/src/main/java/land/leets/Carrot/domain/post/repository/PostSnapshotRepository.java
+++ b/src/main/java/land/leets/Carrot/domain/post/repository/PostSnapshotRepository.java
@@ -8,12 +8,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PostSnapshotRepository extends JpaRepository<PostSnapshot, Long> {
-    @Override
-    Optional<PostSnapshot> findById(Long aLong);
 
+    @Query("SELECT postSnapshot FROM PostSnapshot postSnapshot WHERE postSnapshot.post.postId = :postId")
     Optional<PostSnapshot> findByPostIdAndIsLastestTrue(Long postId);
 
-    @Query("SELECT postsnapshot from PostSnapshot postsnapshot WHERE postsnapshot.title LIKE %:keyword%")
+    @Query("SELECT postSnapshot from PostSnapshot postSnapshot WHERE postSnapshot.title LIKE %:keyword% AND postSnapshot.isLastest = true ")
     Optional<List<PostSnapshot>> findByKeywordAndIsLastestTrue(@Param("keyword") String keyword);
 
 }

--- a/src/main/java/land/leets/Carrot/domain/post/service/PostService.java
+++ b/src/main/java/land/leets/Carrot/domain/post/service/PostService.java
@@ -76,8 +76,12 @@ public class PostService {
                 .getId());
 
         PostSnapshot postSnapshot = PostDataMapper.postDataToPostSnapshot(postData, doAreaId, siAreaId, detailAreaId,
-                jobTypeId, postId);
+                jobTypeId, getPost(postId));
         return postSnapshot;
+    }
+
+    private Post getPost(Long postId) {
+        return postRepository.findById(postId).orElseThrow(() -> new PostException(POST_NOT_FOUND));
     }
 
     @Transactional
@@ -99,7 +103,7 @@ public class PostService {
         return detailArea.getAreaId();
     }
 
-    public ResponseDto<PostResponse> getPost(Long postId) {
+    public ResponseDto<PostResponse> getDetailPost(Long postId) {
         //존재 여부 조회
         Post post = postRepository.findById(postId).orElseThrow(
                 () -> new PostException(PostErrorMessage.POST_NOT_FOUND));
@@ -124,8 +128,8 @@ public class PostService {
         List<ShortPostData> shortPostDataList = new ArrayList<>();
 
         for (PostSnapshot postSnapshot : postSnapshotList) {
-            Post post = postRepository.findById(postSnapshot.getPostId())
-                    .orElseThrow(() -> new PostException(POST_NOT_FOUND));
+            Post post = postSnapshot.getPost();
+
             ShortPostData shortPostData = new ShortPostData(post.getPostId(), postSnapshot.getTitle(),
                     post.getStoreName(), getAreaName
                     (postSnapshot.getDetailAreaId()),
@@ -140,16 +144,14 @@ public class PostService {
 
     @Transactional
     public void updatePostStatusDelete(Long postId) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new PostException(POST_NOT_FOUND));
+        Post post = getPost(postId);
         post.setStatus(POST_STATUS_DELETED);
         postRepository.save(post);
     }
 
     @Transactional
     public void updatePostStatusDone(Long postId) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new PostException(POST_NOT_FOUND));
+        Post post = getPost(postId);
         post.setStatus(POST_STATUS_DONE);
         postRepository.save(post);
     }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
close #37 
PostSnapshot과 Post매핑관계를 Jpa 어노테이션을 사용하지 않고 id값을 기록하는 방법으로 과거에 구현하였었습니다. 
마이페이지의 본인이 지원한 공고 API를 구현하던 중 Post-PostSnapshot 매핑관계를 사용하면 더 간단하게 구현 될 수 있다고 판단되 매핑관계 구현 방법을 수정하게되었습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항
PostSnapshot에 postId를 저장해서 매핑관계를 구현해놓았던 것을 JPA 어노테이션을 통해 구현하였습니다.
<br>

## 5. 추가 사항
