### PR TITLE
Fix: post 관련 API 수정

### DIFF
--- a/src/main/java/land/leets/Carrot/domain/post/controller/PostController.java
+++ b/src/main/java/land/leets/Carrot/domain/post/controller/PostController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -82,8 +83,9 @@ public class PostController {
         postService.updatePostStatusDone(postId);
         return ResponseEntity.ok().build();
     }
-    @PostMapping(consumes = {"multipart/form-data"})
-    public ResponseEntity<Void> postPostImages(@ModelAttribute PostPostImageRequest requestBody){
+
+    @PostMapping(value = "/images", consumes = "multipart/form-data")
+    public ResponseEntity<Void> postPostImages(@RequestPart PostPostImageRequest requestBody){
         postService.getImageUrlList(requestBody);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/land/leets/Carrot/domain/post/controller/PostController.java
+++ b/src/main/java/land/leets/Carrot/domain/post/controller/PostController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import land.leets.Carrot.domain.career.service.WorkTypeService;
 import land.leets.Carrot.domain.post.dto.request.GetPostedPostRequest;
+import land.leets.Carrot.domain.post.dto.request.PostPostImageRequest;
 import land.leets.Carrot.domain.post.dto.request.PostPostRequest;
 import land.leets.Carrot.domain.post.dto.response.PostResponse;
 import land.leets.Carrot.domain.post.dto.response.PostedPostResponse;
@@ -32,7 +33,7 @@ public class PostController {
     private final WorkTypeService workTypeService;
 
     @PostMapping
-    public ResponseEntity<Void> postNewPost(@ModelAttribute @Valid PostPostRequest requestBody) {
+    public ResponseEntity<Void> postNewPost(@RequestBody @Valid PostPostRequest requestBody) {
         postService.saveNewPost(requestBody);
         return ResponseEntity.ok().build();
     }
@@ -62,7 +63,7 @@ public class PostController {
 
     @GetMapping("/user/posted")
     public ResponseEntity<ResponseDto<PostedPostResponse>> getPostedPostList(
-            @RequestBody GetPostedPostRequest requestBody) {
+            @RequestBody @Valid GetPostedPostRequest requestBody) {
         return ResponseEntity.ok(postService.getPostedPostList(requestBody));
     }
 
@@ -79,6 +80,11 @@ public class PostController {
     @PatchMapping("/status/{postId}")
     public ResponseEntity<Void> getPostStatusDone(@PathVariable Long postId) {
         postService.updatePostStatusDone(postId);
+        return ResponseEntity.ok().build();
+    }
+    @PostMapping(consumes = {"multipart/form-data"})
+    public ResponseEntity<Void> postPostImages(@ModelAttribute PostPostImageRequest requestBody){
+        postService.getImageUrlList(requestBody);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/post/controller/PostController.java
+++ b/src/main/java/land/leets/Carrot/domain/post/controller/PostController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,15 +32,15 @@ public class PostController {
     private final WorkTypeService workTypeService;
 
     @PostMapping
-    public ResponseEntity<Void> postNewPost(@RequestBody @Valid PostPostRequest requestBody) {
+    public ResponseEntity<Void> postNewPost(@ModelAttribute @Valid PostPostRequest requestBody) {
         postService.saveNewPost(requestBody);
         return ResponseEntity.ok().build();
     }
 
 
     @PostMapping("/{postId}")
-    public ResponseEntity<Void> updatePost(@PathVariable Long postId, @RequestBody @Valid PostPostRequest requestBody) {
-        postService.saveNewPostSnapshot(postId, requestBody);
+    public ResponseEntity<Void> updatePost(@PathVariable Long postId, @ModelAttribute @Valid PostPostRequest requestBody) {
+        postService.updatePost(postId, requestBody);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/land/leets/Carrot/domain/post/controller/PostController.java
+++ b/src/main/java/land/leets/Carrot/domain/post/controller/PostController.java
@@ -16,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -41,7 +40,7 @@ public class PostController {
 
 
     @PostMapping("/{postId}")
-    public ResponseEntity<Void> updatePost(@PathVariable Long postId, @ModelAttribute @Valid PostPostRequest requestBody) {
+    public ResponseEntity<Void> updatePost(@PathVariable Long postId, @RequestBody @Valid PostPostRequest requestBody) {
         postService.updatePost(postId, requestBody);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/land/leets/Carrot/domain/post/domain/PostData.java
+++ b/src/main/java/land/leets/Carrot/domain/post/domain/PostData.java
@@ -17,7 +17,7 @@ public record PostData(
         Integer workEndTimeMinute,
         Boolean isNegotiable,
         String applyNumber,
-        String workDays, //","로 구분해서 String 으로 받는 가정, 단기알바인 경우
+        List<String> workDays, //근무 요일
         Boolean isShortTermJob,
         LocalDateTime lastUpdatedTime,
         String payType,

--- a/src/main/java/land/leets/Carrot/domain/post/domain/PostData.java
+++ b/src/main/java/land/leets/Carrot/domain/post/domain/PostData.java
@@ -2,6 +2,7 @@ package land.leets.Carrot.domain.post.domain;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public record PostData(
         String doName,
@@ -22,6 +23,7 @@ public record PostData(
         LocalDateTime lastUpdatedTime,
         String payType,
         Boolean isNumberPublic,
+        List<MultipartFile> imageList,
         List<String> imageUrlList) {
 
 }

--- a/src/main/java/land/leets/Carrot/domain/post/domain/PostData.java
+++ b/src/main/java/land/leets/Carrot/domain/post/domain/PostData.java
@@ -23,7 +23,6 @@ public record PostData(
         LocalDateTime lastUpdatedTime,
         String payType,
         Boolean isNumberPublic,
-        List<MultipartFile> imageList,
         List<String> imageUrlList) {
 
 }

--- a/src/main/java/land/leets/Carrot/domain/post/domain/PostData.java
+++ b/src/main/java/land/leets/Carrot/domain/post/domain/PostData.java
@@ -2,7 +2,6 @@ package land.leets.Carrot.domain.post.domain;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import org.springframework.web.multipart.MultipartFile;
 
 public record PostData(
         String doName,

--- a/src/main/java/land/leets/Carrot/domain/post/dto/request/PostPostImageRequest.java
+++ b/src/main/java/land/leets/Carrot/domain/post/dto/request/PostPostImageRequest.java
@@ -1,0 +1,9 @@
+package land.leets.Carrot.domain.post.dto.request;
+
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public record PostPostImageRequest(
+        List<MultipartFile> imageList
+) {
+}

--- a/src/main/java/land/leets/Carrot/domain/post/dto/request/PostPostRequest.java
+++ b/src/main/java/land/leets/Carrot/domain/post/dto/request/PostPostRequest.java
@@ -9,6 +9,8 @@ public record PostPostRequest(
         Long userId,
         @NotNull
         String storeName,
+        @NotNull
+        String workPlaceAddress,
         PostData postData
 
 ) {

--- a/src/main/java/land/leets/Carrot/domain/post/dto/request/PostPostRequest.java
+++ b/src/main/java/land/leets/Carrot/domain/post/dto/request/PostPostRequest.java
@@ -5,11 +5,8 @@ import land.leets.Carrot.domain.post.domain.PostData;
 
 public record PostPostRequest(
         Long postId,
-        @NotNull
         Long userId,
-        @NotNull
         String storeName,
-        @NotNull
         String workPlaceAddress,
         PostData postData
 

--- a/src/main/java/land/leets/Carrot/domain/post/dto/response/PostResponse.java
+++ b/src/main/java/land/leets/Carrot/domain/post/dto/response/PostResponse.java
@@ -9,6 +9,7 @@ public record PostResponse(
         Long userId,
         @NotNull
         String storeName,
+        String workPlaceAddress,
         String writerNickname,
         PostData postData
 

--- a/src/main/java/land/leets/Carrot/domain/post/entity/Post.java
+++ b/src/main/java/land/leets/Carrot/domain/post/entity/Post.java
@@ -36,6 +36,8 @@ public class Post extends BaseTimeEntity {
     @Column(name = "store_name", nullable = false)
     private String storeName;
 
+    private String workPlaceAddress;
+
     //조회수 기능 mvp 이후 구현
     @Column(name = "create_at", nullable = false)
     private LocalDateTime createAt;
@@ -48,9 +50,10 @@ public class Post extends BaseTimeEntity {
     private Set<Apply> apply;
 
     @Builder
-    public Post(Ceo ceo, String storeName, LocalDateTime createAt, String status) {
+    public Post(Ceo ceo, String storeName, String workPlaceAddress, LocalDateTime createAt, String status) {
         this.ceo = ceo;
         this.storeName = storeName;
+        this.workPlaceAddress = workPlaceAddress;
         this.createAt = createAt;
         this.status = status;
     }

--- a/src/main/java/land/leets/Carrot/domain/post/entity/PostImage.java
+++ b/src/main/java/land/leets/Carrot/domain/post/entity/PostImage.java
@@ -1,0 +1,35 @@
+package land.leets.Carrot.domain.post.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class PostImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String imageUrl;
+
+    @ManyToOne
+    @JoinColumn(name = "post_snapshot_id", nullable = false)
+    private PostSnapshot postSnapshot;
+
+    @Builder
+    public PostImage(String imageUrl, PostSnapshot postSnapshot){
+        this.imageUrl = imageUrl;
+        this.postSnapshot = postSnapshot;
+    }
+}

--- a/src/main/java/land/leets/Carrot/domain/post/entity/PostSnapshot.java
+++ b/src/main/java/land/leets/Carrot/domain/post/entity/PostSnapshot.java
@@ -93,7 +93,8 @@ public class PostSnapshot extends BaseTimeEntity {
                         String applyNumber,
                         boolean isLastest,
                         boolean isNumberPublic,
-                        String payType) {
+                        String payType,
+                        Set<DayOfWeek> selectedDays) {
         this.doAreaId = doAreaId;
         this.siAreaId = siAreaId;
         this.detailAreaId = detailAreaId;

--- a/src/main/java/land/leets/Carrot/domain/post/entity/PostSnapshot.java
+++ b/src/main/java/land/leets/Carrot/domain/post/entity/PostSnapshot.java
@@ -4,9 +4,11 @@ import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.EnumSet;
 import java.util.Set;
@@ -78,6 +80,9 @@ public class PostSnapshot extends BaseTimeEntity {
     @CreationTimestamp
     private LocalDateTime createdAt;
 
+    @OneToMany(mappedBy = "postsnapshot", fetch = FetchType.LAZY)
+    private Set<PostImage> postImages;
+
     @Builder
     public PostSnapshot(int doAreaId,
                         int siAreaId,
@@ -115,7 +120,7 @@ public class PostSnapshot extends BaseTimeEntity {
         this.payType = payType;
     }
 
-    public void setIsLastest(boolean isLastest){
+    public void setIsLastest(boolean isLastest) {
         this.isLastest = isLastest;
     }
 

--- a/src/main/java/land/leets/Carrot/domain/post/entity/PostSnapshot.java
+++ b/src/main/java/land/leets/Carrot/domain/post/entity/PostSnapshot.java
@@ -80,7 +80,7 @@ public class PostSnapshot extends BaseTimeEntity {
     @CreationTimestamp
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "postsnapshot", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "postSnapshot", fetch = FetchType.LAZY)
     private Set<PostImage> postImages;
 
     @Builder

--- a/src/main/java/land/leets/Carrot/domain/post/mapper/PostDataMapper.java
+++ b/src/main/java/land/leets/Carrot/domain/post/mapper/PostDataMapper.java
@@ -1,6 +1,8 @@
 package land.leets.Carrot.domain.post.mapper;
 
+import java.util.stream.Collectors;
 import land.leets.Carrot.domain.post.domain.PostData;
+import land.leets.Carrot.domain.post.entity.DayOfWeek;
 import land.leets.Carrot.domain.post.entity.PostSnapshot;
 import org.springframework.stereotype.Component;
 
@@ -27,7 +29,10 @@ public class PostDataMapper {
                 .applyNumber(postData.applyNumber())
                 .isLastest(true)
                 .isNumberPublic(postData.isNumberPublic())
-                .payType(postData.payType()).build();
+                .payType(postData.payType())
+                .selectedDays(
+                        postData.workDays().stream().map(day -> DayOfWeek.valueOf(day)).collect(Collectors.toSet()))
+                .build();
         //TODO 선택한 날짜 enum Set 이전필요
 
     }

--- a/src/main/java/land/leets/Carrot/domain/post/mapper/PostSnapshotMapper.java
+++ b/src/main/java/land/leets/Carrot/domain/post/mapper/PostSnapshotMapper.java
@@ -1,17 +1,26 @@
 package land.leets.Carrot.domain.post.mapper;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import land.leets.Carrot.domain.post.domain.PostData;
+import land.leets.Carrot.domain.post.entity.DayOfWeek;
 import land.leets.Carrot.domain.post.entity.PostSnapshot;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PostSnapshotMapper {
     public static PostData postSnaphotToPostData(PostSnapshot postSnapshot, String doName, String siName,
-                                                 String detailName, String workDays, String workType) {
+                                                 String detailName, Set<DayOfWeek> workDays, String workType) {
+        List<String> workDaysList = workDays.stream()
+                .map(Enum::name)
+                .collect(Collectors.toList());
+
         return new PostData(doName, siName, detailName, workType, postSnapshot.getTitle(), postSnapshot.getContent(),
                 postSnapshot.getPay(), postSnapshot.getWorkStartHour(), postSnapshot.getWorkStartMinute(),
                 postSnapshot.getWorkEndHour(), postSnapshot.getWorkEndMinute(), postSnapshot.isNegotiable(),
-                postSnapshot.getApplyNumber(), workDays, false, postSnapshot.getCreatedAt(), postSnapshot.getPayType(),
+                postSnapshot.getApplyNumber(), workDaysList, false,
+                postSnapshot.getCreatedAt(), postSnapshot.getPayType(),
                 postSnapshot.isNumberPublic(), null//TODO 이미지 관련 작업 추후 진행 예정
         );
     }

--- a/src/main/java/land/leets/Carrot/domain/post/mapper/PostSnapshotMapper.java
+++ b/src/main/java/land/leets/Carrot/domain/post/mapper/PostSnapshotMapper.java
@@ -11,7 +11,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class PostSnapshotMapper {
     public static PostData postSnaphotToPostData(PostSnapshot postSnapshot, String doName, String siName,
-                                                 String detailName, Set<DayOfWeek> workDays, String workType) {
+                                                 String detailName, Set<DayOfWeek> workDays, String workType,
+                                                 List<String> imageUrlList) {
         List<String> workDaysList = workDays.stream()
                 .map(Enum::name)
                 .collect(Collectors.toList());
@@ -21,7 +22,7 @@ public class PostSnapshotMapper {
                 postSnapshot.getWorkEndHour(), postSnapshot.getWorkEndMinute(), postSnapshot.isNegotiable(),
                 postSnapshot.getApplyNumber(), workDaysList, false,
                 postSnapshot.getCreatedAt(), postSnapshot.getPayType(),
-                postSnapshot.isNumberPublic(), null//TODO 이미지 관련 작업 추후 진행 예정
+                postSnapshot.isNumberPublic(), null, imageUrlList
         );
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/post/mapper/PostSnapshotMapper.java
+++ b/src/main/java/land/leets/Carrot/domain/post/mapper/PostSnapshotMapper.java
@@ -22,7 +22,7 @@ public class PostSnapshotMapper {
                 postSnapshot.getWorkEndHour(), postSnapshot.getWorkEndMinute(), postSnapshot.isNegotiable(),
                 postSnapshot.getApplyNumber(), workDaysList, false,
                 postSnapshot.getCreatedAt(), postSnapshot.getPayType(),
-                postSnapshot.isNumberPublic(), null, imageUrlList
+                postSnapshot.isNumberPublic(), imageUrlList
         );
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/land/leets/Carrot/domain/post/repository/PostImageRepository.java
@@ -1,0 +1,12 @@
+package land.leets.Carrot.domain.post.repository;
+
+import java.util.List;
+import land.leets.Carrot.domain.post.entity.PostImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+    @Query("SELECT p FROM PostImage p WHERE p.postSnapshot.id = :postsnapshotId")
+    List<PostImage> findByPostSnapshotId(@Param("postsnapshotId") Long postsnapshotId);
+}

--- a/src/main/java/land/leets/Carrot/domain/post/repository/PostSnapshotRepository.java
+++ b/src/main/java/land/leets/Carrot/domain/post/repository/PostSnapshotRepository.java
@@ -11,6 +11,7 @@ public interface PostSnapshotRepository extends JpaRepository<PostSnapshot, Long
     @Override
     Optional<PostSnapshot> findById(Long aLong);
 
+    @Query("SELECT postsnapshot FROM PostSnapshot postsnapshot WHERE postsnapshot.postId= :postId and postsnapshot.isLastest = true")
     Optional<PostSnapshot> findByPostIdAndIsLastestTrue(Long postId);
 
     @Query("SELECT postsnapshot from PostSnapshot postsnapshot WHERE postsnapshot.title LIKE %:keyword%")

--- a/src/main/java/land/leets/Carrot/domain/post/service/PostService.java
+++ b/src/main/java/land/leets/Carrot/domain/post/service/PostService.java
@@ -64,8 +64,8 @@ public class PostService {
 
     public void saveNewPost(PostPostRequest postPostRequest) {
         Post post = new Post(ceoRepository.findById(postPostRequest.userId())
-                .orElseThrow(() -> new PostException(USER_NOT_FOUND)), postPostRequest.storeName(), LocalDateTime.now(),
-                POST_STATUS_RECRUITING);
+                .orElseThrow(() -> new PostException(USER_NOT_FOUND)), postPostRequest.storeName(),
+                postPostRequest.workPlaceAddress(), LocalDateTime.now(), POST_STATUS_RECRUITING);
         Post savedPost = postRepository.save(post);
 
         PostSnapshot postSnapshot = getPostSnapshot(postPostRequest, savedPost.getPostId());
@@ -137,7 +137,7 @@ public class PostService {
 
         String workType = getWorkTypeName(postSnapshot.getWorkTypeId());
         PostResponse postResponse = new PostResponse(postId, post.getCeo().getId(), post.getStoreName(),
-                post.getCeo().getCeoName(),
+                post.getWorkPlaceAddress(), post.getCeo().getCeoName(),
                 PostSnapshotMapper.postSnaphotToPostData(postSnapshot, getAreaName(postSnapshot.getDoAreaId())
                         , getAreaName(postSnapshot.getSiAreaId()), getAreaName(postSnapshot.getDetailAreaId()),
                         postSnapshot.getSelectedDays(), workType, imageList));

--- a/src/main/java/land/leets/Carrot/domain/post/service/PostService.java
+++ b/src/main/java/land/leets/Carrot/domain/post/service/PostService.java
@@ -13,8 +13,10 @@ import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import land.leets.Carrot.domain.career.entity.WorkType;
 import land.leets.Carrot.domain.career.repository.WorkTypeRepository;
+import land.leets.Carrot.domain.image.service.S3ImageService;
 import land.leets.Carrot.domain.location.entity.DetailArea;
 import land.leets.Carrot.domain.location.repository.LocationRepository;
 import land.leets.Carrot.domain.post.controller.SuccessMessage;
@@ -28,17 +30,20 @@ import land.leets.Carrot.domain.post.dto.response.PostedPostResponse;
 import land.leets.Carrot.domain.post.dto.response.ShortPostResponse;
 import land.leets.Carrot.domain.post.entity.DayOfWeek;
 import land.leets.Carrot.domain.post.entity.Post;
+import land.leets.Carrot.domain.post.entity.PostImage;
 import land.leets.Carrot.domain.post.entity.PostSnapshot;
 import land.leets.Carrot.domain.post.exception.PostErrorMessage;
 import land.leets.Carrot.domain.post.exception.PostException;
 import land.leets.Carrot.domain.post.mapper.PostDataMapper;
 import land.leets.Carrot.domain.post.mapper.PostSnapshotMapper;
+import land.leets.Carrot.domain.post.repository.PostImageRepository;
 import land.leets.Carrot.domain.post.repository.PostRepository;
 import land.leets.Carrot.domain.post.repository.PostSnapshotRepository;
 import land.leets.Carrot.domain.user.repository.CeoRepository;
 import land.leets.Carrot.global.common.response.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
@@ -50,6 +55,8 @@ public class PostService {
 
     private final WorkTypeRepository workTypeRepository;
     private final CeoRepository ceoRepository;
+    private final S3ImageService s3ImageService;
+    private final PostImageRepository postImageRepository;
 
     private static final String POST_STATUS_RECRUITING = "recruiting";
     private static final String POST_STATUS_DELETED = "deleted";
@@ -63,7 +70,17 @@ public class PostService {
 
         PostSnapshot postSnapshot = getPostSnapshot(postPostRequest, savedPost.getPostId());
 
-        postSnapshotRepository.save(postSnapshot);
+        PostSnapshot savedSnapshot = postSnapshotRepository.save(postSnapshot);
+
+        savePostSnapshotImage(postPostRequest.postData().imageList(), savedSnapshot);
+    }
+
+    private void savePostSnapshotImage(List<MultipartFile> imageList, PostSnapshot postSnapshot) {
+        for (MultipartFile image : imageList) {
+            String imageUrl = s3ImageService.uploadImage(image, "post-images");
+            PostImage postImage = new PostImage(imageUrl, postSnapshot);
+            postImageRepository.save(postImage);
+        }
     }
 
     private PostSnapshot getPostSnapshot(PostPostRequest postPostRequest, Long postId) {
@@ -82,7 +99,7 @@ public class PostService {
     }
 
     @Transactional
-    public void saveNewPostSnapshot(Long postId, PostPostRequest postPostRequest) {
+    public void updatePost(Long postId, PostPostRequest postPostRequest) {
         //기존 snapshot isLastest false로 수정
         PostSnapshot postSnapshot = postSnapshotRepository.findByPostIdAndIsLastestTrue(postId)
                 .orElseThrow(() -> new PostException(LATEST_SNAPSHOT_NOT_FOUND));
@@ -94,7 +111,10 @@ public class PostService {
 
         //PostSnapshot 생성해서 새 PostSnapshot 저장
         PostSnapshot newPostSnapshot = getPostSnapshot(postPostRequest, postId);
-        postSnapshotRepository.save(newPostSnapshot);
+        PostSnapshot savedPostSnapshot = postSnapshotRepository.save(newPostSnapshot);
+
+        savePostSnapshotImage(postPostRequest.postData().imageList(), savedPostSnapshot);
+
     }
 
     public Integer getAreaId(String areaName) {
@@ -111,12 +131,16 @@ public class PostService {
         PostSnapshot postSnapshot = postSnapshotRepository.findByPostIdAndIsLastestTrue(postId)
                 .orElseThrow(() -> new PostException(LATEST_SNAPSHOT_NOT_FOUND));
 
+        List<String> imageList = postImageRepository.findByPostSnapshotId(postSnapshot.getId())
+                .stream()
+                .map(image -> image.getImageUrl()).collect(Collectors.toList());
+
         String workType = getWorkTypeName(postSnapshot.getWorkTypeId());
         PostResponse postResponse = new PostResponse(postId, post.getCeo().getId(), post.getStoreName(),
                 post.getCeo().getCeoName(),
                 PostSnapshotMapper.postSnaphotToPostData(postSnapshot, getAreaName(postSnapshot.getDoAreaId())
                         , getAreaName(postSnapshot.getSiAreaId()), getAreaName(postSnapshot.getDetailAreaId()),
-                        postSnapshot.getSelectedDays(), workType));
+                        postSnapshot.getSelectedDays(), workType, imageList));
 
         return new ResponseDto(SuccessMessage.GET_POST_DETAIL_SUCCESS.getCode(),
                 SuccessMessage.GET_POST_DETAIL_SUCCESS.getMessage(), postResponse);
@@ -133,7 +157,8 @@ public class PostService {
             ShortPostData shortPostData = new ShortPostData(post.getPostId(), postSnapshot.getTitle(),
                     post.getStoreName(), getAreaName
                     (postSnapshot.getDetailAreaId()),
-                    postSnapshot.getPayType(), (long) postSnapshot.getPay(), post.getStatus(), ""//TODO 이미지 작업 추후 진행 예정
+                    postSnapshot.getPayType(), (long) postSnapshot.getPay(), post.getStatus(),
+                    getFirstImageUrl(postSnapshot.getId())
             );
             shortPostDataList.add(shortPostData);
         }
@@ -166,11 +191,13 @@ public class PostService {
         for (Post post : postList) {
             PostSnapshot postSnapshot = postSnapshotRepository.findByPostIdAndIsLastestTrue(post.getPostId())
                     .orElseThrow(() -> new PostException(LATEST_SNAPSHOT_NOT_FOUND));
+            getFirstImageUrl(postSnapshot.getId());
+
             ShortPostData shortPostData = new ShortPostData(post.getPostId(), postSnapshot.getTitle(),
                     post.getStoreName(), getAreaName(
                     postSnapshot.getDetailAreaId()), postSnapshot.getPayType(), (long) postSnapshot.getPay(),
                     post.getStatus(),
-                    "");    //TODO 이미지 관련 작업 차후 구현 예정
+                    getFirstImageUrl(postSnapshot.getId()));
             shortPostDataList.add(shortPostData);
         }
         return new ResponseDto(SuccessMessage.GET_POST_LIST_SHORT_DATA_VER.getCode(),
@@ -186,11 +213,16 @@ public class PostService {
             PostSnapshot postSnapshot = postSnapshotRepository.findByPostIdAndIsLastestTrue(post.getPostId())
                     .orElseThrow(() -> new PostException(LATEST_SNAPSHOT_NOT_FOUND));
             PostedPost postedPost = new PostedPost(post.getPostId(), postSnapshot.getTitle(),
-                    getAreaName(postSnapshot.getDetailAreaId()), post.getStatus().equals(POST_STATUS_RECRUITING), "");
+                    getAreaName(postSnapshot.getDetailAreaId()), post.getStatus().equals(POST_STATUS_RECRUITING),
+                    getFirstImageUrl(postSnapshot.getId()));
             postedPostDataList.add(postedPost);
         }
         return new ResponseDto(SuccessMessage.GET_POSTED_POST_LIST_SUCCESS.getCode(),
                 SuccessMessage.GET_POSTED_POST_LIST_SUCCESS.getMessage(), new PostedPostResponse(postedPostDataList));
+    }
+
+    private String getFirstImageUrl(Long postSnapshotId) {
+        return postImageRepository.findByPostSnapshotId(postSnapshotId).get(0).getImageUrl();
     }
 
 

--- a/src/main/java/land/leets/Carrot/domain/post/service/PostService.java
+++ b/src/main/java/land/leets/Carrot/domain/post/service/PostService.java
@@ -26,6 +26,7 @@ import land.leets.Carrot.domain.post.dto.request.PostPostRequest;
 import land.leets.Carrot.domain.post.dto.response.PostResponse;
 import land.leets.Carrot.domain.post.dto.response.PostedPostResponse;
 import land.leets.Carrot.domain.post.dto.response.ShortPostResponse;
+import land.leets.Carrot.domain.post.entity.DayOfWeek;
 import land.leets.Carrot.domain.post.entity.Post;
 import land.leets.Carrot.domain.post.entity.PostSnapshot;
 import land.leets.Carrot.domain.post.exception.PostErrorMessage;
@@ -86,6 +87,9 @@ public class PostService {
         PostSnapshot postSnapshot = postSnapshotRepository.findByPostIdAndIsLastestTrue(postId)
                 .orElseThrow(() -> new PostException(LATEST_SNAPSHOT_NOT_FOUND));
         postSnapshot.setIsLastest(false);
+        for (String day : postPostRequest.postData().workDays()) {
+            postSnapshot.selectDay(DayOfWeek.valueOf(day));
+        }
         postSnapshotRepository.save(postSnapshot);
 
         //PostSnapshot 생성해서 새 PostSnapshot 저장
@@ -112,7 +116,7 @@ public class PostService {
                 post.getCeo().getCeoName(),
                 PostSnapshotMapper.postSnaphotToPostData(postSnapshot, getAreaName(postSnapshot.getDoAreaId())
                         , getAreaName(postSnapshot.getSiAreaId()), getAreaName(postSnapshot.getDetailAreaId()),
-                        getWorkTypeName(postSnapshot.getWorkTypeId()), workType));
+                        postSnapshot.getSelectedDays(), workType));
 
         return new ResponseDto(SuccessMessage.GET_POST_DETAIL_SUCCESS.getCode(),
                 SuccessMessage.GET_POST_DETAIL_SUCCESS.getMessage(), postResponse);


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
close #33 
게시글 수정 api 수정,
게시글 내 이미지 업로드, 저장 관련 로직 수정, 
게시글 이미지 업로드 api 구현,
게시글 로직 내 enumSet 적용
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- 이미지 여러장 한번에 업로그 API 관련

이미지 한장 업로드 시에는 json형식으로 구현이 가능하지만 1개의 API의 requestBody에 여러 이미지를 List<MultiPartFile> 에 담아 요청할 때에는 json으로는 불가하고 formData의 형식을 사용하는 것이 일반적인 것으로 구글링 상 파악이 되어 현재시점에서는 폼데이터 형식으로 구현하였습니다.

일단 해당 브랜치에서 글 수정 API, 글 작성API등 여러 로직이 수정, 구현이 진행되었고, 모두 테스트 완료하였습니다. 
하지만 여러 이미지를 업로드 하는 API는 처음 구현해 보는 것이라 약간 불안하긴 하지만 이미지 업로드 하는 API도 현재로는 기능적으로 db에 저장, 조회가 가능한 것이 확인해 merge진행하려 합니다. 

추후 해당 하나의 공고에 이미지 여러장 업로드 하는 API에 문제 발생시에도 다른 API, 로직과의 의존성 또는 연결된 부분이 없어 독립적으로 해당 API만 기능하지 않고 타 기능에 영향을 주지 않을 것으로 확인하였습니다. 
게시글 이미지 여러장 업로드 API에 대한 개별 브랜치 분기해 리팩터링, 수정 진행할 계획입니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
