### PR TITLE
Refactor : 컨트롤러 데이터 형식 및 응답 형식 통일

### DIFF
--- a/src/main/java/land/leets/Carrot/domain/user/controller/ResponseMessage.java
+++ b/src/main/java/land/leets/Carrot/domain/user/controller/ResponseMessage.java
@@ -2,28 +2,29 @@ package land.leets.Carrot.domain.user.controller;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 public enum ResponseMessage {
 
-    //로그인 회원가입 관련
-    EMAIL_CHECK_SUCCESS(200, "이메일 중복 체크 성공."),
-    USER_SAVE_SUCCESS(201, "회원가입 성공."),
-    LOGIN_SUCCESS(200, "로그인 성공."),
+    // 로그인 및 회원가입 관련
+    EMAIL_CHECK_SUCCESS(HttpStatus.OK.value(), "이메일 중복 체크 성공."),
+    USER_SAVE_SUCCESS(HttpStatus.CREATED.value(), "회원가입 성공."),
+    LOGIN_SUCCESS(HttpStatus.OK.value(), "로그인 성공."),
 
-    //마이페이지(프로필) 관련
-    PROFILE_CHECK_SUCCESS(200, "프로필 조회 성공."),
-    BASIC_INFO_UPDATE_SUCCESS(200, "프로필 기본정보 수정 성공"),
-    CAREER_UPDATE_SUCCESS(200, "경력 정보 수정 성공"),
-    SELF_INTRO_UPDATE_SUCCESS(200, "자기소개 정보 수정 성공"),
-    ADDITIONAL_INFO_UPDATE_SUCCESS(200, "추가 정보 수정 성공"),
-    STRENGTH_UPDATE_SUCCESS(200, "장점 정보 수정 성공"),
+    // 마이페이지(프로필) 관련
+    PROFILE_CHECK_SUCCESS(HttpStatus.OK.value(), "프로필 조회 성공."),
+    BASIC_INFO_UPDATE_SUCCESS(HttpStatus.OK.value(), "프로필 기본정보 수정 성공"),
+    CAREER_UPDATE_SUCCESS(HttpStatus.OK.value(), "경력 정보 수정 성공"),
+    SELF_INTRO_UPDATE_SUCCESS(HttpStatus.OK.value(), "자기소개 정보 수정 성공"),
+    ADDITIONAL_INFO_UPDATE_SUCCESS(HttpStatus.OK.value(), "추가 정보 수정 성공"),
+    STRENGTH_UPDATE_SUCCESS(HttpStatus.OK.value(), "장점 정보 수정 성공"),
 
     // 이미지 업로드 관련
-    IMAGE_UPLOAD_SUCCESS(200, "이미지 업로드 성공."),
-    IMAGE_UPDATE_SUCCESS(200, "이미지 수정 성공."),
-    IMAGE_DELETE_SUCCESS(200, "이미지 삭제 성공.");
+    IMAGE_UPLOAD_SUCCESS(HttpStatus.OK.value(), "이미지 업로드 성공."),
+    IMAGE_UPDATE_SUCCESS(HttpStatus.OK.value(), "이미지 수정 성공."),
+    IMAGE_DELETE_SUCCESS(HttpStatus.OK.value(), "이미지 삭제 성공.");
 
     private final int code;
     private final String message;

--- a/src/main/java/land/leets/Carrot/domain/user/controller/UserController.java
+++ b/src/main/java/land/leets/Carrot/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package land.leets.Carrot.domain.user.controller;
 
+import static land.leets.Carrot.domain.user.controller.ResponseMessage.EMAIL_CHECK_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.LOGIN_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.USER_SAVE_SUCCESS;
 import static land.leets.Carrot.global.common.response.ResponseDto.response;
@@ -42,7 +43,7 @@ public class UserController {
     public ResponseEntity<ResponseDto<Void>> checkEmailDuplicate(@RequestParam String email) {
         userService.checkEmailDuplicate(email);
         return ResponseEntity.ok(
-                response(USER_SAVE_SUCCESS.getCode(), USER_SAVE_SUCCESS.getMessage())
+                response(EMAIL_CHECK_SUCCESS.getCode(), EMAIL_CHECK_SUCCESS.getMessage())
         );
     }
 

--- a/src/main/java/land/leets/Carrot/domain/user/controller/UserProfileController.java
+++ b/src/main/java/land/leets/Carrot/domain/user/controller/UserProfileController.java
@@ -112,20 +112,20 @@ public class UserProfileController {
 
     @PostMapping("/upload-profile-image")
     @Operation(summary = "프로필 이미지 업로드")
-    public ResponseEntity<ResponseDto<String>> uploadProfileImage(
+    public ResponseEntity<ResponseDto<Void>> uploadProfileImage(
             @RequestParam("image") MultipartFile image,
             @Parameter(hidden = true) @CurrentUser Long userId) {
         String imageUrl = s3ImageService.uploadImage(image, "profile-images");
         userProfileService.updateProfileImageUrl(userId, imageUrl);
         return ResponseEntity.ok(
                 ResponseDto.response(IMAGE_UPLOAD_SUCCESS.getCode(),
-                        IMAGE_UPLOAD_SUCCESS.getMessage(), imageUrl)
+                        IMAGE_UPLOAD_SUCCESS.getMessage())
         );
     }
 
     @PatchMapping("/update-profile-image")
     @Operation(summary = "프로필 이미지 수정")
-    public ResponseEntity<ResponseDto<String>> updateProfileImage(
+    public ResponseEntity<ResponseDto<Void>> updateProfileImage(
             @RequestParam("image") MultipartFile image,
             @RequestParam("oldFileName") String oldFileName,
             @Parameter(hidden = true) @CurrentUser Long userId) {
@@ -133,7 +133,7 @@ public class UserProfileController {
         userProfileService.updateProfileImageUrl(userId, imageUrl);
         return ResponseEntity.ok(
                 ResponseDto.response(IMAGE_UPDATE_SUCCESS.getCode(),
-                        IMAGE_UPDATE_SUCCESS.getMessage(), imageUrl)
+                        IMAGE_UPDATE_SUCCESS.getMessage())
         );
     }
 

--- a/src/main/java/land/leets/Carrot/domain/user/controller/UserProfileController.java
+++ b/src/main/java/land/leets/Carrot/domain/user/controller/UserProfileController.java
@@ -19,6 +19,7 @@ import land.leets.Carrot.domain.user.dto.request.EmployeeAdditionalInfoUpdateReq
 import land.leets.Carrot.domain.user.dto.request.EmployeeCareerUpdateRequest;
 import land.leets.Carrot.domain.user.dto.request.EmployeeSelfIntroUpdateRequest;
 import land.leets.Carrot.domain.user.dto.request.EmployeeStrengthUpdateRequest;
+import land.leets.Carrot.domain.user.dto.response.ProfileResponse;
 import land.leets.Carrot.domain.user.service.UserProfileService;
 import land.leets.Carrot.global.auth.annotation.CurrentUser;
 import land.leets.Carrot.global.common.response.ResponseDto;
@@ -43,8 +44,8 @@ public class UserProfileController {
 
     @GetMapping("/profile")
     @Operation(summary = "프로필 메인 페이지")
-    public ResponseEntity<ResponseDto<?>> check(@Parameter(hidden = true) @CurrentUser Long userId) {
-        var profileResponse = userProfileService.check(userId);
+    public ResponseEntity<ResponseDto<ProfileResponse>> check(@Parameter(hidden = true) @CurrentUser Long userId) {
+        ProfileResponse profileResponse = userProfileService.check(userId);
         return ResponseEntity.ok(ResponseDto.response(
                 PROFILE_CHECK_SUCCESS.getCode(),
                 PROFILE_CHECK_SUCCESS.getMessage(),

--- a/src/main/java/land/leets/Carrot/domain/user/dto/response/CeoProfileResponse.java
+++ b/src/main/java/land/leets/Carrot/domain/user/dto/response/CeoProfileResponse.java
@@ -1,20 +1,16 @@
 package land.leets.Carrot.domain.user.dto.response;
 
 import land.leets.Carrot.domain.user.entity.Ceo;
-import land.leets.Carrot.domain.user.entity.Gender;
 import lombok.Getter;
 
 @Getter
-public class CeoProfileResponse {
+public class CeoProfileResponse extends ProfileResponse {
     private final String ceoName;
     private final String ceoPhoneNumber;
-    private final Gender gender;
-    private final Integer birthYear;
 
     public CeoProfileResponse(Ceo ceo) {
+        super(ceo.getGender(), ceo.getBirthYear());
         this.ceoName = ceo.getCeoName();
         this.ceoPhoneNumber = ceo.getCeoPhoneNumber();
-        this.gender = ceo.getGender();
-        this.birthYear = ceo.getBirthYear();
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/user/dto/response/EmployeeProfileResponse.java
+++ b/src/main/java/land/leets/Carrot/domain/user/dto/response/EmployeeProfileResponse.java
@@ -1,22 +1,18 @@
 package land.leets.Carrot.domain.user.dto.response;
 
 import land.leets.Carrot.domain.user.entity.Employee;
-import land.leets.Carrot.domain.user.entity.Gender;
 import lombok.Getter;
 
 @Getter
-public class EmployeeProfileResponse {
+public class EmployeeProfileResponse extends ProfileResponse {
     private final String employeeName;
     private final String employeeAddress;
     private final String phoneNumber;
-    private final Gender gender;
-    private final Integer birthYear;
 
     public EmployeeProfileResponse(Employee employee) {
+        super(employee.getGender(), employee.getBirthYear());
         this.employeeName = employee.getEmployeeName();
         this.employeeAddress = employee.getEmployeeAddress();
         this.phoneNumber = employee.getPhoneNumber();
-        this.gender = employee.getGender();
-        this.birthYear = employee.getBirthYear();
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/user/dto/response/ProfileResponse.java
+++ b/src/main/java/land/leets/Carrot/domain/user/dto/response/ProfileResponse.java
@@ -1,0 +1,15 @@
+package land.leets.Carrot.domain.user.dto.response;
+
+import land.leets.Carrot.domain.user.entity.Gender;
+import lombok.Getter;
+
+@Getter
+public abstract class ProfileResponse {
+    private final Gender gender;
+    private final Integer birthYear;
+
+    protected ProfileResponse(Gender gender, Integer birthYear) {
+        this.gender = gender;
+        this.birthYear = birthYear;
+    }
+}

--- a/src/main/java/land/leets/Carrot/domain/user/exception/ErrorMessage.java
+++ b/src/main/java/land/leets/Carrot/domain/user/exception/ErrorMessage.java
@@ -2,29 +2,31 @@ package land.leets.Carrot.domain.user.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 
 @Getter
 @AllArgsConstructor
 public enum ErrorMessage {
     // 회원가입 관련
-    EMAIL_ALREADY_EXISTS(400, "이미 존재하는 이메일입니다."),
-    TEL_ALREADY_EXISTS(400, "이미 등록된 전화번호입니다."),
-    CEONUMBER_ALREADY_EXISTS(400, "이미 존재하는 사업자 번호입니다"),
-    CEONAME_ALREADY_EXISTS(400, "이미 존재하는 대표자명입니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 이메일입니다."),
+    TEL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST.value(), "이미 등록된 전화번호입니다."),
+    CEONUMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 사업자 번호입니다"),
+    CEONAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 대표자명입니다."),
 
     // 로그인 관련
-    USER_NOT_FOUND(404, "존재하지 않는 유저입니다."),
-    INVALID_PASSWORD(401, "비밀번호가 일치하지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 유저입니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED.value(), "비밀번호가 일치하지 않습니다."),
 
     // 유저 프로필 관련
-    UNKNOWN_USER_TYPE(400, "정의되지 않은 유저 타입입니다."),
-    INVALID_USER_TYPE(400, "구직자만 수정 가능한 정보입니다."),
+    UNKNOWN_USER_TYPE(HttpStatus.BAD_REQUEST.value(), "정의되지 않은 유저 타입입니다."),
+    INVALID_USER_TYPE(HttpStatus.BAD_REQUEST.value(), "구직자만 수정 가능한 정보입니다."),
 
     // 이미지 업로드 관련
-    INVALID_FILE_EXTENSION(400, "유효하지 않은 파일 형식입니다."),
-    FILE_CONVERSION_FAILED(500, "파일 변환에 실패했습니다."),
-    IMAGE_DELETE_FAILED(500, "이미지 삭제에 실패했습니다.");
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 파일 형식입니다."),
+    FILE_CONVERSION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "파일 변환에 실패했습니다."),
+    IMAGE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "이미지 삭제에 실패했습니다.");
+
 
     private final int code;
     private final String message;

--- a/src/main/java/land/leets/Carrot/domain/user/service/LoginService.java
+++ b/src/main/java/land/leets/Carrot/domain/user/service/LoginService.java
@@ -27,7 +27,7 @@ public class LoginService {
         if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new InvalidPasswordException();
         }
-        String token = jwtProvider.generateAccessToken(user.getEmail());
+        String token = jwtProvider.generateAccessToken(user.getEmail(), user.getId());
         response.setHeader("Authorization", "Bearer " + token);
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/user/service/UserProfileService.java
+++ b/src/main/java/land/leets/Carrot/domain/user/service/UserProfileService.java
@@ -8,6 +8,7 @@ import land.leets.Carrot.domain.user.dto.request.EmployeeSelfIntroUpdateRequest;
 import land.leets.Carrot.domain.user.dto.request.EmployeeStrengthUpdateRequest;
 import land.leets.Carrot.domain.user.dto.response.CeoProfileResponse;
 import land.leets.Carrot.domain.user.dto.response.EmployeeProfileResponse;
+import land.leets.Carrot.domain.user.dto.response.ProfileResponse;
 import land.leets.Carrot.domain.user.entity.Ceo;
 import land.leets.Carrot.domain.user.entity.Employee;
 import land.leets.Carrot.domain.user.entity.User;
@@ -24,7 +25,7 @@ public class UserProfileService {
     private final UserRepository userRepository;
 
     @Transactional
-    public Object check(Long userId) {
+    public ProfileResponse check(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 

--- a/src/main/java/land/leets/Carrot/global/auth/jwt/dto/JwtFilter.java
+++ b/src/main/java/land/leets/Carrot/global/auth/jwt/dto/JwtFilter.java
@@ -64,7 +64,6 @@ public class JwtFilter extends OncePerRequestFilter {
         UserDetails userDetails = org.springframework.security.core.userdetails.User.builder()
                 .username(user.getEmail())
                 .password(user.getPassword())
-                .roles(user.getUserType().name())
                 .build();
 
         UsernamePasswordAuthenticationToken authentication =

--- a/src/main/java/land/leets/Carrot/global/auth/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/land/leets/Carrot/global/auth/resolver/CurrentUserArgumentResolver.java
@@ -1,8 +1,11 @@
 package land.leets.Carrot.global.auth.resolver;
 
-import land.leets.Carrot.domain.user.entity.User;
+import java.util.Optional;
 import land.leets.Carrot.global.auth.annotation.CurrentUser;
+import land.leets.Carrot.global.auth.jwt.dto.JwtProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -12,7 +15,10 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
+@RequiredArgsConstructor
 public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+    private final JwtProvider jwtProvider;
+
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(CurrentUser.class);
@@ -22,10 +28,15 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null && authentication.isAuthenticated()) {
-            User user = (User) authentication.getPrincipal();
-            return user.getId(); // ID를 반환
+        if (authentication instanceof AnonymousAuthenticationToken) {
+            throw new IllegalArgumentException("익명 사용자로부터의 요청은 지원되지 않습니다.");
         }
-        return null;
+
+        String token = Optional.ofNullable(webRequest.getHeader("Authorization"))
+                .map(accessToken -> accessToken.replace("Bearer ", ""))
+                .orElseThrow(() -> new IllegalArgumentException("Authorization 헤더가 누락되었습니다."));
+
+        return jwtProvider.extractId(token)
+                .orElseThrow(() -> new IllegalStateException("유효하지 않은 토큰이거나 토큰에 ID 정보가 없습니다."));
     }
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
프로필 관련 응답 형식의 일관성을 위해 공통 필드와 반환 타입을 통일했습니다.
모든 성공, 예외 응답 메시지에 HTTP 상태 코드를 적용했습니다
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
JWT ID 추출: id를 클레임에서 추출하는 로직을 추가해서 CurrentUser가 제대로 작동하도록 했습니다
<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
