### PR TITLE
Refactor : 경력사항 추가 로직 변경

### DIFF
--- a/src/main/java/land/leets/Carrot/domain/user/controller/ResponseMessage.java
+++ b/src/main/java/land/leets/Carrot/domain/user/controller/ResponseMessage.java
@@ -16,7 +16,8 @@ public enum ResponseMessage {
     // 마이페이지(프로필) 관련
     PROFILE_CHECK_SUCCESS(HttpStatus.OK.value(), "프로필 조회 성공."),
     BASIC_INFO_UPDATE_SUCCESS(HttpStatus.OK.value(), "프로필 기본정보 수정 성공"),
-    CAREER_UPDATE_SUCCESS(HttpStatus.OK.value(), "경력 정보 수정 성공"),
+    CAREER_ADD_SUCCESS(HttpStatus.OK.value(), "경력사항 추가 성공"),
+    CAREER_DELETE_SUCCESS(HttpStatus.OK.value(), "경력사항 삭제 성공"),
     SELF_INTRO_UPDATE_SUCCESS(HttpStatus.OK.value(), "자기소개 정보 수정 성공"),
     ADDITIONAL_INFO_UPDATE_SUCCESS(HttpStatus.OK.value(), "추가 정보 수정 성공"),
     STRENGTH_UPDATE_SUCCESS(HttpStatus.OK.value(), "장점 정보 수정 성공"),

--- a/src/main/java/land/leets/Carrot/domain/user/controller/UserProfileController.java
+++ b/src/main/java/land/leets/Carrot/domain/user/controller/UserProfileController.java
@@ -2,7 +2,8 @@ package land.leets.Carrot.domain.user.controller;
 
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.ADDITIONAL_INFO_UPDATE_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.BASIC_INFO_UPDATE_SUCCESS;
-import static land.leets.Carrot.domain.user.controller.ResponseMessage.CAREER_UPDATE_SUCCESS;
+import static land.leets.Carrot.domain.user.controller.ResponseMessage.CAREER_ADD_SUCCESS;
+import static land.leets.Carrot.domain.user.controller.ResponseMessage.CAREER_DELETE_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.IMAGE_DELETE_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.IMAGE_UPDATE_SUCCESS;
 import static land.leets.Carrot.domain.user.controller.ResponseMessage.IMAGE_UPLOAD_SUCCESS;
@@ -16,7 +17,8 @@ import jakarta.validation.Valid;
 import land.leets.Carrot.domain.image.service.S3ImageService;
 import land.leets.Carrot.domain.user.dto.request.AdditionalInfoUpdateRequest;
 import land.leets.Carrot.domain.user.dto.request.BasicInfoUpdateRequest;
-import land.leets.Carrot.domain.user.dto.request.CareerUpdateRequest;
+import land.leets.Carrot.domain.user.dto.request.CareerAddRequest;
+import land.leets.Carrot.domain.user.dto.request.CareerDeleteRequest;
 import land.leets.Carrot.domain.user.dto.request.SelfIntroUpdateRequest;
 import land.leets.Carrot.domain.user.dto.request.StrengthUpdateRequest;
 import land.leets.Carrot.domain.user.dto.response.EmployeeProfileResponse;
@@ -27,6 +29,7 @@ import land.leets.Carrot.domain.user.service.UserProfileService;
 import land.leets.Carrot.global.auth.annotation.CurrentUser;
 import land.leets.Carrot.global.common.response.ResponseDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,6 +42,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/user-profiles")
@@ -124,14 +128,26 @@ public class UserProfileController {
         ));
     }
 
-    @PatchMapping("/update-career")
+    @PostMapping("/add-career")
     @Operation(summary = "구직자 경력사항 추가")
-    public ResponseEntity<ResponseDto<Void>> updateCareer(@RequestBody @Valid CareerUpdateRequest request,
-                                                          @Parameter(hidden = true) @CurrentUser Long userId) {
-        userProfileService.updateCareer(request, userId);
+    public ResponseEntity<ResponseDto<Void>> addCareer(@RequestBody @Valid CareerAddRequest request,
+                                                       @Parameter(hidden = true) @CurrentUser Long userId) {
+        log.info("CareerAddRequest: {}", request);
+        userProfileService.addCareer(request, userId);
         return ResponseEntity.ok(
-                ResponseDto.response(CAREER_UPDATE_SUCCESS.getCode(),
-                        CAREER_UPDATE_SUCCESS.getMessage())
+                ResponseDto.response(CAREER_ADD_SUCCESS.getCode(),
+                        CAREER_ADD_SUCCESS.getMessage())
+        );
+    }
+
+    @DeleteMapping("/delete-career")
+    @Operation(summary = "구직자 경력사항 삭제")
+    public ResponseEntity<ResponseDto<Void>> deleteCareer(@RequestBody @Valid CareerDeleteRequest request,
+                                                          @Parameter(hidden = true) @CurrentUser Long userId) {
+        userProfileService.deleteCareer(request, userId);
+        return ResponseEntity.ok(
+                ResponseDto.response(CAREER_DELETE_SUCCESS.getCode(),
+                        CAREER_DELETE_SUCCESS.getMessage())
         );
     }
 

--- a/src/main/java/land/leets/Carrot/domain/user/dto/request/CareerAddRequest.java
+++ b/src/main/java/land/leets/Carrot/domain/user/dto/request/CareerAddRequest.java
@@ -1,0 +1,12 @@
+package land.leets.Carrot.domain.user.dto.request;
+
+public record CareerAddRequest(
+        String workplace, // 일한 곳
+        String workType,  // 했던 일
+        String workYear,  // 일한 연도
+        String workPeriod // 일한 기간
+) {
+    public static CareerAddRequest of(String workplace, String workType, String workYear, String workPeriod) {
+        return new CareerAddRequest(workplace, workType, workYear, workPeriod);
+    }
+}

--- a/src/main/java/land/leets/Carrot/domain/user/dto/request/CareerDeleteRequest.java
+++ b/src/main/java/land/leets/Carrot/domain/user/dto/request/CareerDeleteRequest.java
@@ -1,0 +1,9 @@
+package land.leets.Carrot.domain.user.dto.request;
+
+public record CareerDeleteRequest(
+        Long careerId
+) {
+    public static CareerDeleteRequest of(Long careerId) {
+        return new CareerDeleteRequest(careerId);
+    }
+}

--- a/src/main/java/land/leets/Carrot/domain/user/dto/response/CareerResponse.java
+++ b/src/main/java/land/leets/Carrot/domain/user/dto/response/CareerResponse.java
@@ -1,0 +1,19 @@
+package land.leets.Carrot.domain.user.dto.response;
+
+import land.leets.Carrot.domain.user.entity.CareerDetails;
+
+public record CareerResponse(
+        String workplace,  // 일한 곳
+        String workType,   // 했던 일
+        String workYear,   // 일한 연도
+        String workPeriod  // 일한 기간
+) {
+    public static CareerResponse from(CareerDetails careerDetails) {
+        return new CareerResponse(
+                careerDetails.getWorkplace(),
+                careerDetails.getWorkType(),
+                careerDetails.getWorkYear(),
+                careerDetails.getWorkPeriod()
+        );
+    }
+}

--- a/src/main/java/land/leets/Carrot/domain/user/dto/response/EmployeeProfileResponse.java
+++ b/src/main/java/land/leets/Carrot/domain/user/dto/response/EmployeeProfileResponse.java
@@ -1,5 +1,7 @@
 package land.leets.Carrot.domain.user.dto.response;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import land.leets.Carrot.domain.user.entity.Employee;
 import land.leets.Carrot.domain.user.entity.Gender;
 
@@ -7,10 +9,7 @@ public record EmployeeProfileResponse(
         String phoneNumber,
         String employeeName,
         String employeeAddress,
-        String workplace,
-        String workType,
-        String workYear,
-        String workPeriod,
+        List<CareerResponse> careers,
         String selfIntro,
         boolean isSmoke,
         boolean isLongWork,
@@ -32,10 +31,9 @@ public record EmployeeProfileResponse(
                 employee.getPhoneNumber(),
                 employee.getEmployeeName(),
                 employee.getEmployeeAddress(),
-                employee.getWorkplace(),
-                employee.getWorkType(),
-                employee.getWorkYear(),
-                employee.getWorkPeriod(),
+                employee.getCareerDetails().stream()
+                        .map(CareerResponse::from)
+                        .collect(Collectors.toList()),
                 employee.getSelfIntro(),
                 employee.isSmoke(),
                 employee.isLongWork(),

--- a/src/main/java/land/leets/Carrot/domain/user/entity/Career.java
+++ b/src/main/java/land/leets/Carrot/domain/user/entity/Career.java
@@ -1,0 +1,44 @@
+package land.leets.Carrot.domain.user.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Career {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String workplace;
+    private String workType;
+    private String workYear;
+    private String workPeriod;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Employee employee;
+
+    public Career(String workplace, String workType, String workYear, String workPeriod, Employee employee) {
+        this.workplace = workplace;
+        this.workType = workType;
+        this.workYear = workYear;
+        this.workPeriod = workPeriod;
+        this.employee = employee;
+    }
+
+    public void update(String workplace, String workType, String workYear, String workPeriod) {
+        this.workplace = workplace;
+        this.workType = workType;
+        this.workYear = workYear;
+        this.workPeriod = workPeriod;
+    }
+}

--- a/src/main/java/land/leets/Carrot/domain/user/entity/CareerDetails.java
+++ b/src/main/java/land/leets/Carrot/domain/user/entity/CareerDetails.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Entity
-public class Career {
+public class CareerDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -27,12 +27,12 @@ public class Career {
     @JoinColumn(name = "user_id")
     private Employee employee;
 
-    public Career(String workplace, String workType, String workYear, String workPeriod, Employee employee) {
+    public CareerDetails(Employee employee, String workplace, String workType, String workYear, String workPeriod) {
+        this.employee = employee;
         this.workplace = workplace;
         this.workType = workType;
         this.workYear = workYear;
         this.workPeriod = workPeriod;
-        this.employee = employee;
     }
 
     public void update(String workplace, String workType, String workYear, String workPeriod) {

--- a/src/main/java/land/leets/Carrot/domain/user/entity/Employee.java
+++ b/src/main/java/land/leets/Carrot/domain/user/entity/Employee.java
@@ -1,9 +1,12 @@
 package land.leets.Carrot.domain.user.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import land.leets.Carrot.domain.apply.entity.Apply;
 import lombok.Getter;
@@ -61,6 +64,9 @@ public class Employee extends User {
     @OneToMany(mappedBy = "employee", fetch = FetchType.LAZY)
     private Set<Apply> apply;
 
+    @OneToMany(mappedBy = "employee", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Career> careers = new ArrayList<>();
+
     public Employee(String email, String password, String phoneNumber, String employeeName, String employeeAddress) {
         super(email, password);
         this.phoneNumber = phoneNumber;
@@ -95,5 +101,14 @@ public class Employee extends User {
         this.isClean = clean;
         this.isNearHome = nearHome;
         this.isSleepless = sleepless;
+    }
+
+    public void addCareer(String workplace, String workType, String workYear, String workPeriod) {
+        Career career = new Career(workplace, workType, workYear, workPeriod, this);
+        this.careers.add(career);
+    }
+
+    public void deleteCareer(Long careerId) {
+        this.careers.removeIf(career -> career.getId().equals(careerId));
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/user/entity/Employee.java
+++ b/src/main/java/land/leets/Carrot/domain/user/entity/Employee.java
@@ -23,18 +23,6 @@ public class Employee extends User {
     private String employeeAddress;
 
     @Column
-    private String workplace;
-
-    @Column
-    private String workType;
-
-    @Column
-    private String workYear;
-
-    @Column
-    private String workPeriod;
-
-    @Column
     private String selfIntro;
 
     @Column
@@ -85,13 +73,6 @@ public class Employee extends User {
         this.phoneNumber = phoneNumber;
         this.employeeName = employeeName;
         this.employeeAddress = employeeAddress;
-    }
-
-    public void updateCareer(String workplace, String workType, String workYear, String workPeriod) {
-        this.workplace = workplace;
-        this.workType = workType;
-        this.workYear = workYear;
-        this.workPeriod = workPeriod;
     }
 
     public void updateSelfIntro(String selfIntro) {

--- a/src/main/java/land/leets/Carrot/domain/user/entity/Employee.java
+++ b/src/main/java/land/leets/Carrot/domain/user/entity/Employee.java
@@ -65,7 +65,7 @@ public class Employee extends User {
     private Set<Apply> apply;
 
     @OneToMany(mappedBy = "employee", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Career> careers = new ArrayList<>();
+    private List<CareerDetails> careerDetails = new ArrayList<>();
 
     public Employee(String email, String password, String phoneNumber, String employeeName, String employeeAddress) {
         super(email, password);
@@ -104,11 +104,11 @@ public class Employee extends User {
     }
 
     public void addCareer(String workplace, String workType, String workYear, String workPeriod) {
-        Career career = new Career(workplace, workType, workYear, workPeriod, this);
-        this.careers.add(career);
+        CareerDetails careerDetails = new CareerDetails(this, workplace, workType, workYear, workPeriod);
+        this.careerDetails.add(careerDetails);
     }
 
     public void deleteCareer(Long careerId) {
-        this.careers.removeIf(career -> career.getId().equals(careerId));
+        this.careerDetails.removeIf(careerDetails -> careerDetails.getId().equals(careerId));
     }
 }

--- a/src/main/java/land/leets/Carrot/domain/user/service/UserProfileService.java
+++ b/src/main/java/land/leets/Carrot/domain/user/service/UserProfileService.java
@@ -4,7 +4,8 @@ import jakarta.transaction.Transactional;
 import land.leets.Carrot.domain.image.service.S3ImageService;
 import land.leets.Carrot.domain.user.dto.request.AdditionalInfoUpdateRequest;
 import land.leets.Carrot.domain.user.dto.request.BasicInfoUpdateRequest;
-import land.leets.Carrot.domain.user.dto.request.CareerUpdateRequest;
+import land.leets.Carrot.domain.user.dto.request.CareerAddRequest;
+import land.leets.Carrot.domain.user.dto.request.CareerDeleteRequest;
 import land.leets.Carrot.domain.user.dto.request.SelfIntroUpdateRequest;
 import land.leets.Carrot.domain.user.dto.request.StrengthUpdateRequest;
 import land.leets.Carrot.domain.user.dto.response.EmployeeProfileResponse;
@@ -64,17 +65,29 @@ public class UserProfileService {
     }
 
     @Transactional
-    public void updateCareer(CareerUpdateRequest request, Long userId) {
+    public void addCareer(CareerAddRequest request, Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
         if (user instanceof Employee employee) {
-            employee.updateCareer(
+            employee.addCareer(
                     request.workplace(),
                     request.workType(),
                     request.workYear(),
                     request.workPeriod()
             );
+        } else {
+            throw new InvalidUserTypeException();
+        }
+    }
+
+    @Transactional
+    public void deleteCareer(CareerDeleteRequest request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        if (user instanceof Employee employee) {
+            employee.deleteCareer(request.careerId());
         } else {
             throw new InvalidUserTypeException();
         }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
프론트의 요청사항의 맞게 기존 유저 프로필에서 경력사항을 수정할 수 있도록 구성된 로직을,
한 사람당 여러개의 경력사항을 가질 수 있게 경력사항 추가, 삭제 로직으로 변경했습니다
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
![image](https://github.com/user-attachments/assets/56135e2b-de01-4c3b-80de-eec45dc6010f)
![image](https://github.com/user-attachments/assets/466ba538-ad2e-4850-830e-cfe3e9b883c4)
![image](https://github.com/user-attachments/assets/2cf362ad-adcd-4028-a24f-1bf09c6988a6)

<br>

## 4. 완료 사항
경력 추가 API (POST /add-career)
경력 삭제 API (DELETE /delete-career)
경력 정보를 관리할 수 있는 새로운 CareerDetails 엔티티를 추가하여 Employee랑 다대일 관계로 재구성했습니다
구직자가 여러 경력을 가질 수 있도록 구현하여, careerId로 삭제가 가능하도록 했습니다
프로필에서 해당 형태로 경력사항들을 조회할 수 있도록 변경했습니다
<br>

## 5. 추가 사항
경력사항 추가시 carrerId 반환해주는 로직으로 추가 작업하겠습니다